### PR TITLE
skip todo tests

### DIFF
--- a/tests/unit/routes/books-test.js
+++ b/tests/unit/routes/books-test.js
@@ -1,4 +1,4 @@
-import { module, test, todo } from 'qunit';
+import { module, skip, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import EmberObject from '@ember/object';
 import sinon from 'sinon';
@@ -101,7 +101,7 @@ module('Unit | Route | books', hooks => {
       assert.ok(book.rollbackAttributes.calledOnce);
     });
 
-    todo('saveAuthor', function(assert) {
+    skip('saveAuthor', function(assert) {
       // TODO: check if firebase adapter has been fixed
       assert.ok(false);
     });
@@ -120,7 +120,7 @@ module('Unit | Route | books', hooks => {
       assert.ok(book.rollbackAttributes.calledOnce);
     });
 
-    todo('saveLibrary', function(assert) {
+    skip('saveLibrary', function(assert) {
       // TODO: check if firebase adapter has been fixed
       assert.ok(false);
     });


### PR DESCRIPTION
While *todo* tests are displayed as passing in the browser (`ember t --server`), they are reported as failing in the terminal (`ember t`) because `testem` returns non-zero exit code:

![DeepinScreenshot_select-area_20190527135854](https://user-images.githubusercontent.com/271068/58418364-e4dade00-8087-11e9-8edb-735ea62586c4.png)

This confuses a lot of beginners.

Marking them as *skipped* instead of *todo* gives the expected result:
![DeepinScreenshot_select-area_20190527140142](https://user-images.githubusercontent.com/271068/58418496-308d8780-8088-11e9-8518-4dd9a174ee3a.png)
