### PR TITLE
enforce function paren and call spacing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,12 @@ module.exports = {
     'semi': [error, 'always'],
     'indent': [error, 2, {
       'SwitchCase': 1
-    }]
+    }],
+    'space-before-function-paren': [error, {
+      anonymous: 'never',
+      named: 'never'
+    }],
+    'func-call-spacing': [ error, 'never'],
   },
   overrides: [
     // node files

--- a/tests/unit/routes/admin/seeder-test.js
+++ b/tests/unit/routes/admin/seeder-test.js
@@ -8,7 +8,7 @@ const { stub } = sinon;
 module('Unit | Route | admin/seeder', function(hooks) {
   setupTest(hooks);
 
-  hooks.beforeEach(function () {
+  hooks.beforeEach(function() {
     this.model = {
       authors: 'authors',
       books: 'books',
@@ -25,7 +25,7 @@ module('Unit | Route | admin/seeder', function(hooks) {
     });
   });
 
-  test('model hook', async function (assert) {
+  test('model hook', async function(assert) {
     const { model, route } = this;
     assert.expect(4);
     assert.deepEqual(await route.model(), model);
@@ -34,7 +34,7 @@ module('Unit | Route | admin/seeder', function(hooks) {
     assert.ok(route.store.findAll.calledWith('author'));
   });
 
-  test('setupController function', function (assert) {
+  test('setupController function', function(assert) {
     const controller = EmberObject.create();
     assert.expect(3);
     this.route.setupController(controller, this.model);

--- a/tests/unit/routes/authors-test.js
+++ b/tests/unit/routes/authors-test.js
@@ -9,7 +9,7 @@ module('Unit | Route | authors', hooks => {
   setupTest(hooks);
 
 
-  hooks.beforeEach(function () {
+  hooks.beforeEach(function() {
     this.findAll = stub().returns('authors');
     this.route = this.owner.factoryFor('route:authors').create({
       store: { findAll: this.findAll }
@@ -22,13 +22,13 @@ module('Unit | Route | authors', hooks => {
     assert.ok(this.findAll.calledOnceWith('author'));
   });
 
-  test('editAuthor action', function (assert) {
+  test('editAuthor action', function(assert) {
     const author = EmberObject.create();
     this.route.send('editAuthor', author);
     assert.ok(author.get('isEditing'));
   });
 
-  test('cancelAuthorEdit action', function (assert) {
+  test('cancelAuthorEdit action', function(assert) {
     const rollbackAttributes = spy();
     const author = EmberObject.create({
       rollbackAttributes
@@ -38,7 +38,7 @@ module('Unit | Route | authors', hooks => {
     assert.ok(rollbackAttributes.calledOnce);
   });
 
-  test('saveAuthor action', function (assert) {
+  test('saveAuthor action', function(assert) {
     const save = spy();
     const author = EmberObject.create({
       isEditing: true,

--- a/tests/unit/routes/books-test.js
+++ b/tests/unit/routes/books-test.js
@@ -46,7 +46,7 @@ module('Unit | Route | books', hooks => {
 
   module('actions', () => {
 
-    hooks.beforeEach(function () {
+    hooks.beforeEach(function() {
       const rollbackAttributes = spy();
       const save = spy();
       this.book = EmberObject.create({

--- a/tests/unit/routes/contact-test.js
+++ b/tests/unit/routes/contact-test.js
@@ -8,7 +8,7 @@ const { spy, stub } = sinon;
 module('Unit | Route | contact', hooks => {
   setupTest(hooks);
 
-  hooks.beforeEach(function () {
+  hooks.beforeEach(function() {
     this.createRecord = stub().returns('contact');
     this.destroyRecord = spy();
     this.route = this.owner.factoryFor('route:contact').create({

--- a/tests/unit/routes/libraries/edit-test.js
+++ b/tests/unit/routes/libraries/edit-test.js
@@ -8,7 +8,7 @@ const { spy, stub } = sinon;
 module('Unit | Route | libraries/edit', hooks => {
   setupTest(hooks);
 
-  hooks.beforeEach(function () {
+  hooks.beforeEach(function() {
     this.controller = EmberObject.create({
       model: EmberObject.create({
         hasDirtyAttributes: true,

--- a/tests/unit/routes/libraries/index-test.js
+++ b/tests/unit/routes/libraries/index-test.js
@@ -7,7 +7,7 @@ const { spy, stub } = sinon;
 module('Unit | Route | libraris/index', hooks => {
   setupTest(hooks);
 
-  hooks.beforeEach(function () {
+  hooks.beforeEach(function() {
     this.findAll = stub().returns('libraries');
     this.query = stub().returns('libraries');
     this.route = this.owner.factoryFor('route:libraries/index').create({
@@ -43,7 +43,7 @@ module('Unit | Route | libraris/index', hooks => {
     assert.ok(this.query.calledOnceWith('library', queryParams));
   });
 
-  test('deleteLibrary action', function (assert) {
+  test('deleteLibrary action', function(assert) {
     const library = { destroyRecord: spy() };
     stub(window, 'confirm').returns(true);
 

--- a/tests/unit/routes/libraries/new-test.js
+++ b/tests/unit/routes/libraries/new-test.js
@@ -8,7 +8,7 @@ const { spy, stub } = sinon;
 module('Unit | Route | libraries/new', hooks => {
   setupTest(hooks);
 
-  hooks.beforeEach(function () {
+  hooks.beforeEach(function() {
     this.controller = EmberObject.create({
       model: {
         rollbackAttributes: spy()


### PR DESCRIPTION
Eslint rules to:
- [require or disallow a space before function parenthesis](https://eslint.org/docs/rules/space-before-function-paren)
- [require or disallow spacing between function identifiers and their invocations](https://eslint.org/docs/rules/func-call-spacing)