### PR TITLE
pass closure action to save library

### DIFF
--- a/app/components/library-item-form.js
+++ b/app/components/library-item-form.js
@@ -4,11 +4,12 @@ export default Component.extend({
 
   buttonLabel: 'Save',
 
+  // pass an action to override
+  handleClick() {},
+
   actions: {
-
     buttonClicked(param) {
-      this.sendAction('action', param);
+      this.handleClick(param);
     }
-
   }
 });

--- a/app/controllers/libraries/edit.js
+++ b/app/controllers/libraries/edit.js
@@ -1,0 +1,12 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  buttonLabel: 'Save changes',
+  title: 'Edit library',
+
+  actions: {
+    saveLibrary(newLibrary) {
+      newLibrary.save().then(() => this.transitionToRoute('libraries'));
+    }
+  }
+});

--- a/app/controllers/libraries/new.js
+++ b/app/controllers/libraries/new.js
@@ -1,0 +1,12 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  buttonLabel: 'Create',
+  title: 'Create a new library',
+
+  actions: {
+    saveLibrary(newLibrary) {
+      newLibrary.save().then(() => this.transitionToRoute('libraries'));
+    }
+  }
+});

--- a/app/routes/libraries/edit.js
+++ b/app/routes/libraries/edit.js
@@ -6,34 +6,16 @@ export default Route.extend({
     return this.store.findRecord('library', params.library_id);
   },
 
-  setupController(controller, model) {
-    this._super(controller, model);
-
-    controller.set('title', 'Edit library');
-    controller.set('buttonLabel', 'Save changes');
-  },
-
   renderTemplate() {
     this.render('libraries/form');
   },
 
   actions: {
-
-    saveLibrary(library) {
-      library.save().then(() => this.transitionTo('libraries'));
-    },
-
     willTransition(transition) {
-      let model = this.controller.get('model');
-
+      const model = this.controller.get('model');
       if (model.get('hasDirtyAttributes')) {
-        let confirmation = confirm("Your changes haven't saved yet. Would you like to leave this form?");
-
-        if (confirmation) {
-          model.rollbackAttributes();
-        } else {
-          transition.abort();
-        }
+        const confirmation = confirm("Your changes haven't saved yet. Would you like to leave this form?");
+        confirmation ? model.rollbackAttributes() : transition.abort();
       }
     }
   }

--- a/app/routes/libraries/new.js
+++ b/app/routes/libraries/new.js
@@ -6,23 +6,11 @@ export default Route.extend({
     return this.store.createRecord('library');
   },
 
-  setupController(controller, model) {
-    this._super(controller, model);
-
-    controller.set('title', 'Create a new library');
-    controller.set('buttonLabel', 'Create');
-  },
-
   renderTemplate() {
     this.render('libraries/form');
   },
 
   actions: {
-
-    saveLibrary(newLibrary) {
-      newLibrary.save().then(() => this.transitionTo('libraries'));
-    },
-
     willTransition() {
       // rollbackAttributes() removes the record from the store
       // if the model 'isNew'

--- a/app/templates/libraries/form.hbs
+++ b/app/templates/libraries/form.hbs
@@ -1,7 +1,7 @@
 <h2>{{title}}</h2>
 <div class="row">
   <div class="col-md-6">
-    {{library-item-form item=model buttonLabel=buttonLabel action="saveLibrary"}}
+    {{library-item-form item=model buttonLabel=buttonLabel handleClick=(action "saveLibrary")}}
   </div>
   <div class="col-md-4">
     {{#library-item item=model badge=model.books.length}}

--- a/tests/unit/components/library-item-form-test.js
+++ b/tests/unit/components/library-item-form-test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+const { spy } = sinon;
+
+module('Unit | Component | library-item-form', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.component = this.owner.lookup('component:library-item-form');
+  });
+
+  test('label', function(assert) {
+    assert.expect(1);
+    assert.equal(this.component.get('buttonLabel'), 'Save');
+  });
+
+  test('default action exists', function(assert) {
+    assert.expect(1);
+    assert.equal(this.component.handleClick(), undefined);
+  });
+
+  test('buttonClicked action', function(assert) {
+    const { component } = this;
+    component.set('handleClick', spy());
+    component.send('buttonClicked', 'test');
+    assert.expect(1);
+    assert.ok(component.handleClick.calledOnceWith('test'));
+  });
+});

--- a/tests/unit/controllers/libraries/edit-test.js
+++ b/tests/unit/controllers/libraries/edit-test.js
@@ -1,0 +1,30 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+const { spy, stub } = sinon;
+
+module('Unit | Controller | libraries/edit', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.controller = this.owner.lookup('controller:libraries/edit');
+  });
+
+  test('label and title', function(assert) {
+    const { controller } = this;
+    assert.expect(2);
+    assert.equal(controller.get('buttonLabel'), 'Save changes');
+    assert.equal(controller.get('title'), 'Edit library');
+  });
+
+  test('saveLibrary action', function(assert) {
+    const { controller } = this;
+    const save = stub().returns({ then: stub().yields() });
+    controller.set('transitionToRoute', spy());
+    controller.send('saveLibrary', { save });
+    assert.expect(2);
+    assert.ok(save.calledOnce);
+    assert.ok(controller.transitionToRoute.calledOnceWith('libraries'));
+  });
+});

--- a/tests/unit/controllers/libraries/new-test.js
+++ b/tests/unit/controllers/libraries/new-test.js
@@ -1,0 +1,30 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+const { spy, stub } = sinon;
+
+module('Unit | Controller | libraries/new', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.controller = this.owner.lookup('controller:libraries/new');
+  });
+
+  test('label and title', function(assert) {
+    const { controller } = this;
+    assert.expect(2);
+    assert.equal(controller.get('buttonLabel'), 'Create');
+    assert.equal(controller.get('title'), 'Create a new library');
+  });
+
+  test('saveLibrary action', function(assert) {
+    const { controller } = this;
+    const save = stub().returns({ then: stub().yields() });
+    controller.set('transitionToRoute', spy());
+    controller.send('saveLibrary', { save });
+    assert.expect(2);
+    assert.ok(save.calledOnce);
+    assert.ok(controller.transitionToRoute.calledOnceWith('libraries'));
+  });
+});

--- a/tests/unit/routes/libraries/edit-test.js
+++ b/tests/unit/routes/libraries/edit-test.js
@@ -34,27 +34,10 @@ module('Unit | Route | libraries/edit', hooks => {
     assert.ok(this.route.store.findRecord.calledOnceWith('library', 42));
   });
 
-  test('setupController function', function(assert) {
-    const { controller, route } = this;
-    route.setupController(controller);
-    assert.expect(2);
-    assert.equal(controller.get('title'), 'Edit library');
-    assert.equal(controller.get('buttonLabel'), 'Save changes');
-  });
-
   test('renderTemplate function', function(assert) {
     this.route.renderTemplate();
     assert.expect(1);
     assert.ok(this.route.render.calledOnceWith('libraries/form'));
-  });
-
-  test('saveLibrary action', function(assert) {
-    const save = stub().returns({ then: stub().yields() });
-    const newLibrary = { save };
-    this.route.send('saveLibrary', newLibrary);
-    assert.expect(2);
-    assert.ok(save.calledOnce);
-    assert.ok(this.route.transitionTo.calledOnceWith('libraries'));
   });
 
   test('willTransition action', function(assert) {
@@ -64,7 +47,7 @@ module('Unit | Route | libraries/edit', hooks => {
     };
     stub(window, 'confirm').returns(true);
     route.send('willTransition', transition);
-    assert.expect(5);
+    assert.expect(8);
     assert.ok(confirm.calledOnceWith('Your changes haven\'t saved yet. Would you like to leave this form?'));
     assert.ok(controller.get('model').rollbackAttributes.calledOnce);
     assert.ok(transition.abort.notCalled);
@@ -75,6 +58,15 @@ module('Unit | Route | libraries/edit', hooks => {
     route.send('willTransition', transition);
     assert.ok(controller.get('model').rollbackAttributes.notCalled);
     assert.ok(transition.abort.calledOnce);
+
+    transition.abort.resetHistory();
+    confirm.resetHistory();
+    controller.set('model.hasDirtyAttributes', false);
+    route.send('willTransition', transition);
+    assert.ok(confirm.notCalled);
+    assert.ok(transition.abort.notCalled);
+    assert.ok(controller.get('model').rollbackAttributes.notCalled);
     confirm.restore();
+
   });
 });

--- a/tests/unit/routes/libraries/new-test.js
+++ b/tests/unit/routes/libraries/new-test.js
@@ -30,27 +30,10 @@ module('Unit | Route | libraries/new', hooks => {
     assert.ok(this.route.store.createRecord.calledOnceWith('library'));
   });
 
-  test('setupController function', function(assert) {
-    const { controller } = this;
-    this.route.setupController(controller);
-    assert.expect(2);
-    assert.equal(controller.get('title'), 'Create a new library');
-    assert.equal(controller.get('buttonLabel'), 'Create');
-  });
-
   test('renderTemplate function', function(assert) {
     this.route.renderTemplate();
     assert.expect(1);
     assert.ok(this.route.render.calledOnceWith('libraries/form'));
-  });
-
-  test('saveLibrary action', function(assert) {
-    const save = stub().returns({ then: stub().yields() });
-    const newLibrary = { save };
-    this.route.send('saveLibrary', newLibrary);
-    assert.expect(2);
-    assert.ok(save.calledOnce);
-    assert.ok(this.route.transitionTo.calledOnceWith('libraries'));
   });
 
   test('willTransition action', function(assert) {


### PR DESCRIPTION
`sendAction` has been [deprecated](https://deprecations.emberjs.com/v3.x/#toc_ember-component-send-action). Use closure actions instead for saving a library.

Hmm, still trying to figure out whey the test coverage has dropped ...