### PR TITLE
pass closure action to save author and library

### DIFF
--- a/app/components/author-select.js
+++ b/app/components/author-select.js
@@ -7,10 +7,12 @@ export default Component.extend({
   authors: null,
   book: null,
 
+  //pass an action to override
+  onChange() {},
+
   change(event) {
     const selectedAuthorId = event.target.value;
     const selectedAuthor = this.authors.find((record) => record.id === selectedAuthorId);
-
-    this.sendAction('action', selectedAuthor, this.book);
+    this.onChange(selectedAuthor, this.book);
   }
 });

--- a/app/components/library-select.js
+++ b/app/components/library-select.js
@@ -7,10 +7,12 @@ export default Component.extend({
   libraries: null,
   book: null,
 
+  //pass an action to override
+  onChange() {},
+
   change(event) {
     const selectedLibraryId = event.target.value;
     const selectedLibrary = this.libraries.find((record) => record.id === selectedLibraryId);
-
-    this.sendAction('action', selectedLibrary, this.book);
+    this.onChange(selectedLibrary, this.book);
   }
 });

--- a/app/controllers/books.js
+++ b/app/controllers/books.js
@@ -1,0 +1,77 @@
+import Controller from '@ember/controller';
+import { alias } from '@ember/object/computed';
+
+export default Controller.extend({
+  authors: alias('model.authors'),
+  books: alias('model.books'),
+  libraries: alias('model.libraries'),
+
+  actions: {
+    editBook(book) {
+      book.set('isEditing', true);
+    },
+
+    cancelBookEdit(book) {
+      book.set('isEditing', false);
+      book.rollbackAttributes();
+    },
+
+    saveBook(book) {
+      if (book.get('isNotValid')) {
+        return;
+      }
+
+      book.set('isEditing', false);
+      book.save();
+    },
+
+    editAuthor(book) {
+      book.set('isAuthorEditing', true);
+    },
+
+    cancelAuthorEdit(book) {
+      book.set('isAuthorEditing', false);
+      book.rollbackAttributes();
+    },
+
+    saveAuthor(author, book) {
+      // Firebase adapter is buggy, we have to manually remove the previous relation
+      book.get('author').then((previousAuthor) => {
+        previousAuthor.get('books').then((previousAuthorBooks) => {
+          previousAuthorBooks.removeObject(book);
+          previousAuthor.save();
+        });
+      });
+
+      // Setup the new relation
+      book.set('author', author);
+      book.save().then(() => author.save());
+      book.set('isAuthorEditing', false);
+    },
+
+    editLibrary(book) {
+      book.set('isLibraryEditing', true);
+    },
+
+    cancelLibraryEdit(book) {
+      book.set('isLibraryEditing', false);
+      book.rollbackAttributes();
+    },
+
+    saveLibrary(library, book) {
+      // Firebase adapter is buggy, we have to manually remove the previous relation.
+      // You don't need this callback mess when your adapter properly manages relations.
+      // If Firebase fix this bug, we can remove this part.
+      book.get('library').then((previousLibrary) => {
+        previousLibrary.get('books').then((previousLibraryBooks) => {
+          previousLibraryBooks.removeObject(book);
+          previousLibrary.save();
+        });
+      });
+
+      book.set('library', library);
+      book.save().then(() => library.save());
+      book.set('isLibraryEditing', false);
+    }
+  }
+});

--- a/app/routes/books.js
+++ b/app/routes/books.js
@@ -2,7 +2,6 @@ import { hash } from 'rsvp';
 import Route from '@ember/routing/route';
 
 export default Route.extend({
-
   model() {
     return hash({
       books: this.store.findAll('book'),
@@ -10,85 +9,4 @@ export default Route.extend({
       libraries: this.store.findAll('library')
     });
   },
-
-  setupController(controller, model) {
-    const books = model.books;
-    const authors = model.authors;
-    const libraries = model.libraries;
-
-    this._super(controller, books);
-
-    controller.set('authors', authors);
-    controller.set('libraries', libraries);
-  },
-
-  actions: {
-
-    editBook(book) {
-      book.set('isEditing', true);
-    },
-
-    cancelBookEdit(book) {
-      book.set('isEditing', false);
-      book.rollbackAttributes();
-    },
-
-    saveBook(book) {
-      if (book.get('isNotValid')) {
-        return;
-      }
-
-      book.set('isEditing', false);
-      book.save();
-    },
-
-    editAuthor(book) {
-      book.set('isAuthorEditing', true);
-    },
-
-    cancelAuthorEdit(book) {
-      book.set('isAuthorEditing', false);
-      book.rollbackAttributes();
-    },
-
-    saveAuthor(author, book) {
-      // Firebase adapter is buggy, we have to manually remove the previous relation
-      book.get('author').then((previousAuthor) => {
-        previousAuthor.get('books').then((previousAuthorBooks) => {
-          previousAuthorBooks.removeObject(book);
-          previousAuthor.save();
-        });
-      });
-
-      // Setup the new relation
-      book.set('author', author);
-      book.save().then(() => author.save());
-      book.set('isAuthorEditing', false);
-    },
-
-    editLibrary(book) {
-      book.set('isLibraryEditing', true);
-    },
-
-    cancelLibraryEdit(book) {
-      book.set('isLibraryEditing', false);
-      book.rollbackAttributes();
-    },
-
-    saveLibrary(library, book) {
-      // Firebase adapter is buggy, we have to manually remove the previous relation.
-      // You don't need this callback mess when your adapter properly manages relations.
-      // If Firebase fix this bug, we can remove this part.
-      book.get('library').then((previousLibrary) => {
-        previousLibrary.get('books').then((previousLibraryBooks) => {
-          previousLibraryBooks.removeObject(book);
-          previousLibrary.save();
-        });
-      });
-
-      book.set('library', library);
-      book.save().then(() => library.save());
-      book.set('isLibraryEditing', false);
-    }
-  }
 });

--- a/app/templates/books.hbs
+++ b/app/templates/books.hbs
@@ -18,7 +18,7 @@
     </tr>
   </thead>
   <tbody>
-    {{#each model as |book|}}
+    {{#each books as |book|}}
       <tr>
         <td>
           {{#if book.isAuthorEditing}}
@@ -27,8 +27,8 @@
                 book=book
                 authors=authors
                 default=book.author
-                action="saveAuthor"}}
-
+                onChange=(action "saveAuthor")
+            }}
             <button class="btn btn-danger" {{action "cancelAuthorEdit" book}}>Cancel</button>
           {{else}}
             <span role="button" {{action "editAuthor" book}}>{{book.author.name}}</span>
@@ -56,7 +56,8 @@
                 book=book
                 libraries=libraries
                 default=book.library
-                action="saveLibrary"}}
+                onChange=(action "saveLibrary")
+            }}
             <button class="btn btn-danger" {{action "cancelLibraryEdit" book}}>Cancel</button>
           {{else}}
             <span role="button" {{action "editLibrary" book}}>{{book.library.name}}</span>

--- a/tests/unit/controllers/books-test.js
+++ b/tests/unit/controllers/books-test.js
@@ -1,0 +1,104 @@
+import { module, skip, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import EmberObject from '@ember/object';
+import sinon from 'sinon';
+
+const { spy } = sinon;
+
+module('Unit | Controller | books', function(hooks) {
+  setupTest(hooks);
+  hooks.beforeEach(function() {
+    const rollbackAttributes = spy();
+    const save = spy();
+    this.book = EmberObject.create({
+      rollbackAttributes,
+      save
+    });
+    this.controller = this.owner.lookup('controller:books');
+  });
+
+  test('aliased model properties', function(assert) {
+    const { controller } = this;
+    controller.set('model', {
+      authors: 'authors',
+      books: 'books',
+      libraries: 'libraries'
+    });
+    assert.expect(3);
+    assert.equal(controller.get('authors'), 'authors');
+    assert.equal(controller.get('books'), 'books');
+    assert.equal(controller.get('libraries'), 'libraries');
+  });
+
+  test('editBook', function(assert) {
+    const { book, controller } = this;
+    controller.send('editBook', book);
+    assert.expect(1);
+    assert.equal(book.get('isEditing'), true);
+  });
+
+  test('cancelBookEdit', function(assert) {
+    const { book, controller } = this;
+    controller.send('cancelBookEdit', book);
+    assert.expect(2);
+    assert.equal(book.get('isEditing'), false);
+    assert.ok(book.rollbackAttributes.calledOnce);
+  });
+
+  test('saveBook', function(assert) {
+    const { book, controller } = this;
+    controller.send('saveBook', book);
+    assert.expect(4);
+    assert.equal(book.get('isEditing'), false);
+    assert.ok(book.save.calledOnce);
+    book.save.resetHistory();
+
+    book.setProperties({
+      isEditing: true,
+      isNotValid: true
+    });
+    controller.send('saveBook', book);
+    assert.ok(book.get('isEditing'));
+    assert.notOk(book.save.calledOnce);
+  });
+
+  test('editAuthor', function(assert) {
+    const { book, controller } = this;
+    controller.send('editAuthor', book);
+    assert.expect(1);
+    assert.equal(book.get('isAuthorEditing'), true);
+  });
+
+  test('cancelAuthorEdit', function(assert) {
+    const { book, controller } = this;
+    controller.send('cancelAuthorEdit', book);
+    assert.expect(2);
+    assert.equal(book.get('isAuthorEditing'), false);
+    assert.ok(book.rollbackAttributes.calledOnce);
+  });
+
+  skip('saveAuthor', function(assert) {
+    // TODO: check if firebase adapter has been fixed
+    assert.ok(false);
+  });
+
+  test('editLibrary', function(assert) {
+    const { book, controller } = this;
+    controller.send('editLibrary', book);
+    assert.expect(1);
+    assert.equal(book.get('isLibraryEditing'), true);
+  });
+
+  test('cancelLibraryEdit', function(assert) {
+    const { book, controller } = this;
+    controller.send('cancelLibraryEdit', book);
+    assert.expect(2);
+    assert.equal(book.get('isLibraryEditing'), false);
+    assert.ok(book.rollbackAttributes.calledOnce);
+  });
+
+  skip('saveLibrary', function(assert) {
+    // TODO: check if firebase adapter has been fixed
+    assert.ok(false);
+  });
+});

--- a/tests/unit/routes/books-test.js
+++ b/tests/unit/routes/books-test.js
@@ -1,9 +1,8 @@
-import { module, skip, test } from 'qunit';
+import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import EmberObject from '@ember/object';
 import sinon from 'sinon';
 
-const { spy, stub } = sinon;
+const { stub } = sinon;
 
 module('Unit | Route | books', hooks => {
   setupTest(hooks);
@@ -30,99 +29,4 @@ module('Unit | Route | books', hooks => {
     assert.ok(findAll.calledWith('library'));
   });
 
-  test('setupController function', function(assert) {
-    const controller = EmberObject.create();
-    const model = {
-      books: 'books',
-      authors: 'authors',
-      libraries: 'libraries'
-    };
-    const route = this.owner.lookup('route:books');
-    assert.expect(2);
-    route.setupController(controller, model);
-    assert.equal(controller.get('authors'), 'authors');
-    assert.equal(controller.get('libraries'), 'libraries');
-  });
-
-  module('actions', () => {
-
-    hooks.beforeEach(function() {
-      const rollbackAttributes = spy();
-      const save = spy();
-      this.book = EmberObject.create({
-        rollbackAttributes,
-        save
-      });
-      this.route = this.owner.lookup('route:books');
-    });
-
-    test('editBook', function(assert) {
-      this.route.send('editBook', this.book);
-      assert.expect(1);
-      assert.equal(this.book.get('isEditing'), true);
-    });
-
-    test('cancelBookEdit', function(assert) {
-      const { book } = this;
-      this.route.send('cancelBookEdit', book);
-      assert.expect(2);
-      assert.equal(book.get('isEditing'), false);
-      assert.ok(book.rollbackAttributes.calledOnce);
-    });
-
-    test('saveBook', function(assert) {
-      const { book } = this;
-      this.route.send('saveBook', book);
-      assert.expect(4);
-      assert.equal(book.get('isEditing'), false);
-      assert.ok(book.save.calledOnce);
-      book.save.resetHistory();
-
-      book.setProperties({
-        isEditing: true,
-        isNotValid: true
-      });
-      this.route.send('saveBook', book);
-      assert.ok(book.get('isEditing'));
-      assert.notOk(book.save.calledOnce);
-    });
-
-    test('editAuthor', function(assert) {
-      this.route.send('editAuthor', this.book);
-      assert.expect(1);
-      assert.equal(this.book.get('isAuthorEditing'), true);
-    });
-
-    test('cancelAuthorEdit', function(assert) {
-      const { book } = this;
-      this.route.send('cancelAuthorEdit', book);
-      assert.expect(2);
-      assert.equal(book.get('isAuthorEditing'), false);
-      assert.ok(book.rollbackAttributes.calledOnce);
-    });
-
-    skip('saveAuthor', function(assert) {
-      // TODO: check if firebase adapter has been fixed
-      assert.ok(false);
-    });
-
-    test('editLibrary', function(assert) {
-      this.route.send('editLibrary', this.book);
-      assert.expect(1);
-      assert.equal(this.book.get('isLibraryEditing'), true);
-    });
-
-    test('cancelLibraryEdit', function(assert) {
-      const { book } = this;
-      this.route.send('cancelLibraryEdit', book);
-      assert.expect(2);
-      assert.equal(book.get('isLibraryEditing'), false);
-      assert.ok(book.rollbackAttributes.calledOnce);
-    });
-
-    skip('saveLibrary', function(assert) {
-      // TODO: check if firebase adapter has been fixed
-      assert.ok(false);
-    });
-  });
 });


### PR DESCRIPTION
`sendAction` has been [deprecated](https://deprecations.emberjs.com/v3.x/#toc_ember-component-send-action). Use closure actions instead for saving author and library via the `{{author-select}}` and `{{library-select}}` components.