### PR TITLE
pass closure actions for library seeder

### DIFF
--- a/app/components/seeder-block.js
+++ b/app/components/seeder-block.js
@@ -20,19 +20,19 @@ export default Component.extend({
   generateIsDisabled: or('isCounterNotValid', 'generateInProgress', 'deleteInProgress'),
   deleteIsDisabled: or('generateInProgress', 'deleteInProgress'),
 
+  // pass actions to override
+  handleGenerate() {},
+  handleDelete() {},
+
   actions: {
-
-    generateAction() {
+    generate() {
       if (this.isCounterValid) {
-
-        // Action up to Seeder Controller with the requested amount
-        this.sendAction('generateAction', this.counter);
+        this.handleGenerate(this.counter);
       }
     },
 
-    deleteAction() {
-      this.sendAction('deleteAction');
+    delete() {
+      this.handleDelete();
     }
-
   }
 });

--- a/app/templates/admin/seeder.hbs
+++ b/app/templates/admin/seeder.hbs
@@ -8,8 +8,8 @@
 
 {{seeder-block
   sectionTitle="Libraries"
-  generateAction="generateLibraries"
-  deleteAction="deleteLibraries"
+  handleGenerate=(action "generateLibraries")
+  handleDelete=(action "deleteLibraries")
   generateReady=libDone
   deleteReady=libDelDone
   generateInProgress=generateLibrariesInProgress
@@ -18,8 +18,8 @@
 
 {{seeder-block
   sectionTitle="Authors with Books"
-  generateAction="generateBooksAndAuthors"
-  deleteAction="deleteBooksAndAuthors"
+  handleGenerate=(action "generateBooksAndAuthors")
+  handleDelete=(action "deleteBooksAndAuthors")
   generateReady=authDone
   deleteReady=authDelDone
   generateInProgress=generateBooksInProgress

--- a/app/templates/components/seeder-block.hbs
+++ b/app/templates/components/seeder-block.hbs
@@ -5,7 +5,7 @@
       <label class="control-label">Number of new records:</label>
       {{input value=counter class="form-control" placeholder=placeholder}}
     </div>
-    <button class="btn btn-primary" {{action "generateAction"}} disabled={{generateIsDisabled}}>
+    <button class="btn btn-primary" {{action "generate"}} disabled={{generateIsDisabled}}>
       {{#if generateInProgress}}
         <span class="glyphicon glyphicon-refresh spinning"></span> Generating...
       {{else}}
@@ -13,7 +13,7 @@
       {{/if}}
     </button>
     {{#fader-label isShowing=generateReady}}Created!{{/fader-label}}
-    <button class="btn btn-danger" {{action "deleteAction"}} disabled={{deleteIsDisabled}}>
+    <button class="btn btn-danger" {{action "delete"}} disabled={{deleteIsDisabled}}>
       {{#if deleteInProgress}}
         <span class="glyphicon glyphicon-refresh spinning"></span> Deleting...
       {{else}}

--- a/tests/unit/controllers/admin/seeder-test.js
+++ b/tests/unit/controllers/admin/seeder-test.js
@@ -1,0 +1,158 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { next } from '@ember/runloop';
+import EmberObject from '@ember/object';
+import sinon from 'sinon';
+
+const { spy, stub } = sinon;
+
+module('Unit | Controller | admin/seeder', function(hooks) {
+  setupTest(hooks);
+  hooks.beforeEach(function() {
+    const controller = {
+      _destroyAll: stub().resolves(),
+      _saveRandomLibrary: stub().resolves(),
+      _saveRandomAuthor: stub().resolves('newAuthor'),
+      _generateSomeBooks: stub().resolves('books'),
+      authors: 'authors',
+      books: 'books',
+      libraries: 'libraries'
+    };
+    this.controller = this.owner.factoryFor('controller:admin/seeder').create(controller);
+  });
+
+  test('generateLibraries action', function(assert) {
+    const done = assert.async();
+    const { controller } = this;
+    controller.send('generateLibraries', 10);
+    assert.expect(4);
+    assert.equal(controller.get('generateLibrariesInProgress'), true);
+    assert.equal(controller._saveRandomLibrary.callCount, 10);
+
+    next(() => {
+      assert.equal(controller.get('generateLibrariesInProgress'), false);
+      assert.equal(controller.get('libDone'), true);
+      done();
+    });
+  });
+
+  test('deleteLibraries action', function(assert) {
+    const done = assert.async();
+    const { controller } = this;
+    controller.send('deleteLibraries');
+    assert.expect(4);
+    assert.equal(controller.get('deleteLibrariesInProgress'), true);
+    assert.ok(controller._destroyAll.calledOnceWith('libraries'));
+
+    next(() => {
+      assert.equal(controller.get('libDelDone'), true);
+      assert.equal(controller.get('deleteLibrariesInProgress'), false);
+      done();
+    });
+  });
+
+  test('generateBooksAndAuthors action', function(assert) {
+    const done = assert.async();
+    const { controller } = this;
+    controller.send('generateBooksAndAuthors', 10);
+    assert.expect(5);
+    assert.equal(controller.get('generateBooksInProgress'), true);
+    assert.equal(controller._saveRandomAuthor.callCount, 10);
+
+    next(() => {
+      assert.ok(controller._generateSomeBooks.calledWith('newAuthor'));
+      assert.equal(controller.get('authDone'), true);
+      assert.equal(controller.get('generateBooksInProgress'), false);
+      done();
+    });
+  });
+
+  test('deleteBooksAndAuthors action', function(assert) {
+    const done = assert.async();
+    const { controller } = this;
+    controller.send('deleteBooksAndAuthors');
+    assert.expect(4);
+    assert.equal(controller.get('deleteBooksInProgress'), true);
+
+    next(() => {
+      assert.deepEqual(controller._destroyAll.args, [['authors'], ['books']]);
+      assert.equal(controller.get('authDelDone'), true);
+      assert.equal(controller.get('deleteBooksInProgress'), false);
+      done();
+    });
+  });
+
+  module('private methods', function(hooks) {
+    hooks.beforeEach(function() {
+      const save = spy();
+      const randomize = stub().returns({ save });
+      const createRecord = stub().returns({ randomize });
+      const controller = {
+        store: { createRecord }
+      };
+      this.controller = this.owner.factoryFor('controller:admin/seeder').create(controller);
+    });
+
+    test('_saveRandomLibrary function', function(assert) {
+      const { controller } = this;
+      controller._saveRandomLibrary();
+      assert.expect(3);
+      assert.ok(controller.store.createRecord.calledWith('library'));
+      assert.ok(controller.store.createRecord().randomize.calledOnce);
+      assert.ok(controller.store.createRecord().randomize().save.calledOnce);
+    });
+
+    test('_saveRandomAuthor function', function(assert) {
+      const { controller } = this;
+      controller._saveRandomAuthor();
+      assert.expect(3);
+      assert.ok(controller.store.createRecord.calledWith('author'));
+      assert.ok(controller.store.createRecord().randomize.calledOnce);
+      assert.ok(controller.store.createRecord().randomize().save.calledOnce);
+    });
+
+    test('_generateSomeBooks function', function(assert) {
+      const done = assert.async();
+      const { controller } = this;
+      const author = { save: spy() };
+      const library = { save: spy() };
+      const save = stub().resolves();
+      const randomize = stub().returns({ save });
+      const createRecord = stub().returns({ randomize });
+      controller.setProperties({
+        _selectRandomLibrary: stub().returns(library),
+        store: { createRecord }
+      });
+      controller._generateSomeBooks(author);
+      assert.expect(5);
+
+      next(() => {
+        assert.ok(createRecord.calledWith('book'));
+        assert.ok(randomize.calledWith(author, library));
+        assert.ok(save.called);
+        assert.ok(author.save.called);
+        assert.ok(library.save.called);
+        done();
+      });
+    });
+
+    test('_selectRandomLibrary function', function(assert) {
+      const { controller } = this;
+      controller.set('libraries', EmberObject.create(
+        { length: 2, objectAt: spy() }
+      ));
+      controller._selectRandomLibrary();
+      assert.expect(1);
+      assert.ok(controller.libraries.objectAt.calledOnce);
+    });
+
+    test('_destroyAll function', function(assert) {
+      const { controller } = this;
+      const destroyRecord = spy();
+      const records = [{ destroyRecord }, { destroyRecord }];
+      controller._destroyAll(records);
+      assert.expect(1);
+      assert.ok(destroyRecord.calledTwice);
+    });
+  });
+});


### PR DESCRIPTION
This is the final PR to address `sendAction` [deprecation](https://deprecations.emberjs.com/v3.x/#toc_ember-component-send-action). Use closure actions instead for generating and deleting library seeders.