### PR TITLE
add tests for nav-link-to component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  - "12"
 
 sudo: false
 dist: trusty

--- a/testem.js
+++ b/testem.js
@@ -13,9 +13,7 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
-        '--disable-software-rasterizer',
         '--mute-audio',
         '--remote-debugging-port=0',
         '--window-size=1440,900'

--- a/tests/unit/components/nav-link-to-test.js
+++ b/tests/unit/components/nav-link-to-test.js
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import EmberObject from '@ember/object';
+import sinon from 'sinon';
+
+const { spy } = sinon;
+
+module('Unit | Component | nav-link-to', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    const component = {
+      qualifiedRouteName: 'index',
+      models: [],
+      loading: true,
+      loadingHref: '#',
+      _routing: {
+        generateURL: spy()
+      },
+      queryParams: EmberObject.create({
+        values: 'test'
+      })
+
+    };
+    this.component = this
+      .owner
+      .factoryFor('component:nav-link-to')
+      .create(component);
+  });
+
+  test('tagName property', function(assert) {
+    assert.expect(1);
+    assert.equal(this.component.tagName, 'li');
+  });
+
+  test('hrefForA computed property', function(assert) {
+    const { component } = this;
+    assert.expect(3);
+    assert.equal(component.get('hrefForA'), '#');
+    assert.notOk(component._routing.generateURL.called);
+    component._routing.generateURL.resetHistory();
+
+    component.setProperties({
+      loading: false,
+      qualifiedRouteName: 'libraries'
+    });
+    component.get('hrefForA');
+    assert.ok(component._routing.generateURL.calledOnceWith(
+      'libraries',
+      [],
+      'test'
+    ));
+  });
+});


### PR DESCRIPTION
- unit tests for the `{{nav-link-to}}` component
- removed troublesome testem chrome flags as suggested by [this Ember Discuss thread](https://discuss.emberjs.com/t/test-passes-in-server-mode-but-fails-without/16944)
- bumped node version on Travis to support latest JS features such as object spread