### PR TITLE
exclude Ember app files from coverage stats

### DIFF
--- a/config/coverage.js
+++ b/config/coverage.js
@@ -1,3 +1,9 @@
+const { modulePrefix } = require('./environment')();
+
 module.exports = {
+  excludes: [
+    '*/mirage/**/*',
+    `${modulePrefix}/*.js`
+  ],
   reporters: ['lcov', 'text']
 };


### PR DESCRIPTION
This [excludes](https://github.com/kategengler/ember-cli-code-coverage/issues/168) the following files from coverage statistics:

- `app/app.js`
- `app/resolver.js`
- `app/router. js`