### PR TITLE
Add Prettier, npm-run-all, Husky and update Travis tasks fix #54

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,21 +5,16 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module',
     ecmaFeatures: {
-      legacyDecorators: true
-    }
+      legacyDecorators: true,
+    },
   },
-  plugins: [
-    'ember'
-  ],
-  extends: [
-    'eslint:recommended',
-    'plugin:ember/recommended'
-  ],
+  plugins: ['ember'],
+  extends: ['eslint:recommended', 'plugin:ember/recommended', 'plugin:prettier/recommended', 'prettier'],
   env: {
-    browser: true
+    browser: true,
   },
   rules: {
-    'ember/no-jquery': 'error'
+    'ember/no-jquery': 'error',
   },
   overrides: [
     // node files
@@ -32,14 +27,14 @@ module.exports = {
         'blueprints/*/index.js',
         'config/**/*.js',
         'lib/*/index.js',
-        'server/**/*.js'
+        'server/**/*.js',
       ],
       parserOptions: {
-        sourceType: 'script'
+        sourceType: 'script',
       },
       env: {
         browser: false,
-        node: true
+        node: true,
       },
       plugins: ['node'],
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
@@ -47,8 +42,8 @@ module.exports = {
 
         // this can be removed once the following is fixed
         // https://github.com/mysticatea/eslint-plugin-node/issues/77
-        'node/no-unpublished-require': 'off'
-      })
-    }
-  ]
+        'node/no-unpublished-require': 'off',
+      }),
+    },
+  ],
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+.firebase
+coverage
+dist
+node_modules
+tmp
+yarn.lock

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ dist
 node_modules
 tmp
 yarn.lock
+firebase.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 120,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  extends: 'octane'
+  extends: ['recommended', 'octane'],
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 ---
 language: node_js
-node_js:
-  - "12"
+node_js: "12"
+cache: yarn
 
 dist: bionic
 
 addons:
   chrome: stable
-
-cache:
-  directories:
-    - $HOME/.npm
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "12"
 
-dist: trusty
+dist: bionic
 
 addons:
   chrome: stable
@@ -22,10 +22,9 @@ branches:
     - master
 
 script:
-  - npm run lint:hbs
-  - npm run lint:js
-  - npm run test:coverage
+  - yarn ci
 
-after_script:
-  - npm run coveralls
-  - npm run codacy-coverage
+# @TODO Turn back after coveralls and codacy implementation are fixed
+#after_script:
+#  - yarn coveralls
+#  - yarn codacy-coverage

--- a/README.md
+++ b/README.md
@@ -14,27 +14,35 @@ Live demo: [library-app.firebaseapp.com](https://library-app.firebaseapp.com/)
 
 I assume, you have Node.js on your computer. [Node.js installation](http://yoember.com/nodejs/the-best-way-to-install-node-js/)
 
-* Please create an app on [Firebase](http://www.firebase.com) first. You can register there with one click and create a new app. You have to setup this app name in `config/environment.js`. (This will be your own cloud based database.)
+- Please create an app on [Firebase](http://www.firebase.com) first. You can register there with one click and create a new app. You have to setup this app name in `config/environment.js`. (This will be your own cloud based database.)
 
-* Clone this repository in your project folder
+- Clone this repository in your project folder
+
 ```
 $ git clone git@github.com:zoltan-nz/library-app.git
 ```
-* Change to the application directory
+
+- Change to the application directory
+
 ```
 $ cd library-app
 ```
-* Install node packages
+
+- Install node packages
+
 ```
 $ npm install
 ```
 * Copy `.env-sample` file and save as `.env`. Update the `API_KEY` and `PROJECT_ID`.
 
-* Launch the application with Ember server.
+- Launch the application with Ember server.
+
 ```
 $ ember server
 ```
-* Open the application in your browser
+
+- Open the application in your browser
+
 ```
 $ open http://localhost:4200
 ```

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ $ cd library-app
 ```
 $ npm install
 ```
-* Copy `.env-sample` file and save as `.env`. Update the `API_KEY` and `PROJECT_ID`.
 
-- Launch the application with Ember server.
+- Copy `.env-sample` file and save as `.env`. Update the `API_KEY` and `PROJECT_ID`.
+
+* Launch the application with Ember server.
 
 ```
 $ ember server

--- a/app/components/author-select.js
+++ b/app/components/author-select.js
@@ -1,18 +1,18 @@
 import Component from '@glimmer/component';
-import {tracked} from "@glimmer/tracking";
-import {action} from "@ember/object";
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 export default class AuthorSelectComponent extends Component {
   @tracked authors = this.args.authors;
   @tracked book = this.args.book;
-  
+
   //pass an action to override
   @tracked onChange = this.args.onChange;
 
   @action
   change(event) {
     const selectedAuthorId = event.target.value;
-    const selectedAuthor = this.authors.find((record) => record.id === selectedAuthorId);
+    const selectedAuthor = this.authors.find(record => record.id === selectedAuthorId);
     this.onChange(selectedAuthor, this.book);
   }
 }

--- a/app/components/fader-label.js
+++ b/app/components/fader-label.js
@@ -13,7 +13,6 @@ export default Component.extend({
 
   // eslint-disable-next-line ember/no-observers
   isShowingChanged: observer('isShowing', function() {
-
     // User can navigate away from this page in less than 3 seconds, so this component will be destroyed,
     // however our "setTimeout" task try to run.
     // We save this task in a local variable, so we can clean up during the destroy process.
@@ -29,5 +28,5 @@ export default Component.extend({
   willDestroy() {
     this.resetRunLater();
     this._super(...arguments);
-  }
+  },
 });

--- a/app/components/library-item-form.js
+++ b/app/components/library-item-form.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 
 export default Component.extend({
-
   buttonLabel: 'Save',
 
   // pass an action to override
@@ -10,6 +9,6 @@ export default Component.extend({
   actions: {
     buttonClicked(param) {
       this.handleClick(param);
-    }
-  }
+    },
+  },
 });

--- a/app/components/library-item.js
+++ b/app/components/library-item.js
@@ -1,4 +1,3 @@
 import Component from '@ember/component';
 
-export default Component.extend({
-});
+export default Component.extend({});

--- a/app/components/library-select.js
+++ b/app/components/library-select.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 
 export default Component.extend({
-
   tagName: 'select',
   classNames: ['form-control'],
   libraries: null,
@@ -12,7 +11,7 @@ export default Component.extend({
 
   change(event) {
     const selectedLibraryId = event.target.value;
-    const selectedLibrary = this.libraries.find((record) => record.id === selectedLibraryId);
+    const selectedLibrary = this.libraries.find(record => record.id === selectedLibraryId);
     this.onChange(selectedLibrary, this.book);
-  }
+  },
 });

--- a/app/components/nav-link-to.js
+++ b/app/components/nav-link-to.js
@@ -2,7 +2,6 @@ import { computed } from '@ember/object';
 import LinkComponent from '@ember/routing/link-component';
 
 export default LinkComponent.extend({
-
   tagName: 'li',
 
   hrefForA: computed(
@@ -21,6 +20,6 @@ export default LinkComponent.extend({
       const { _route: route, _models: models, _query: query, _routing: routing } = this;
 
       return routing.generateURL(route, models, query);
-    }
-  )
+    },
+  ),
 });

--- a/app/components/number-box.js
+++ b/app/components/number-box.js
@@ -1,7 +1,5 @@
 import Component from '@ember/component';
 
 export default Component.extend({
-
-  classNames: ['panel', 'panel-warning']
-
+  classNames: ['panel', 'panel-warning'],
 });

--- a/app/components/seeder-block.js
+++ b/app/components/seeder-block.js
@@ -4,7 +4,6 @@ import Component from '@ember/component';
 const MAX_VALUE = 100;
 
 export default Component.extend({
-
   counter: null,
 
   isCounterValid: lte('counter', MAX_VALUE),
@@ -33,6 +32,6 @@ export default Component.extend({
 
     delete() {
       this.handleDelete();
-    }
-  }
+    },
+  },
 });

--- a/app/components/spinner-cube.js
+++ b/app/components/spinner-cube.js
@@ -1,4 +1,3 @@
 import Component from '@ember/component';
 
-export default Component.extend({
-});
+export default Component.extend({});

--- a/app/controllers/admin/seeder.js
+++ b/app/controllers/admin/seeder.js
@@ -1,13 +1,11 @@
-import {all} from 'rsvp';
+import { all } from 'rsvp';
 import Controller from '@ember/controller';
-import Faker from "faker";
-import {action} from '@ember/object';
+import Faker from 'faker';
+import { action } from '@ember/object';
 
 export default class SeederController extends Controller {
-
   @action
   generateLibraries(volume) {
-
     // Progress flag, data-down to seeder-block where our lovely button will show a spinner...
     this.set('generateLibrariesInProgress', true);
 
@@ -15,22 +13,19 @@ export default class SeederController extends Controller {
     let savedLibraries = [];
 
     for (let i = 0; i < counter; i++) {
-
       // Collect all Promise in an array
       savedLibraries.push(this._saveRandomLibrary());
     }
 
     // Wait for all Promise to fulfill so we can show our label and turn off the spinner.
-    all(savedLibraries)
-      .then(() => {
-        this.set('generateLibrariesInProgress', false);
-        this.set('libDone', true);
-      });
+    all(savedLibraries).then(() => {
+      this.set('generateLibrariesInProgress', false);
+      this.set('libDone', true);
+    });
   }
 
   @action
   deleteLibraries() {
-
     // Progress flag, data-down to seeder-block button spinner.
     this.set('deleteLibrariesInProgress', true);
 
@@ -47,7 +42,6 @@ export default class SeederController extends Controller {
 
   @action
   generateBooksAndAuthors(volume) {
-
     // Progress flag, data-down to seeder-block button spinner.
     this.set('generateBooksInProgress', true);
 
@@ -55,7 +49,6 @@ export default class SeederController extends Controller {
     let booksWithAuthors = [];
 
     for (let i = 0; i < counter; i++) {
-
       // Collect Promises in an array.
       const books = this._saveRandomAuthor().then(newAuthor => this._generateSomeBooks(newAuthor));
       booksWithAuthors.push(books);
@@ -63,7 +56,6 @@ export default class SeederController extends Controller {
 
     // Let's wait until all async save resolved, show a label and turn off the spinner.
     all(booksWithAuthors)
-
       // Data down via seeder-block to fader-label that we ready to show the label
       // Change the progress flag also, so the spinner can be turned off.
       .then(() => {
@@ -74,7 +66,6 @@ export default class SeederController extends Controller {
 
   @action
   deleteBooksAndAuthors() {
-
     // Progress flag, data-down to seeder-block button to show spinner.
     this.set('deleteBooksInProgress', true);
 
@@ -93,17 +84,22 @@ export default class SeederController extends Controller {
       });
   }
 
-
   // Private methods
 
   // Create a new library record and uses the randomizator, which is in our model and generates some fake data in
   // the new record. After we save it, which is a promise, so this returns a promise.
   _saveRandomLibrary() {
-    return this.store.createRecord('library').randomize().save();
+    return this.store
+      .createRecord('library')
+      .randomize()
+      .save();
   }
 
   _saveRandomAuthor() {
-    return this.store.createRecord('author').randomize().save();
+    return this.store
+      .createRecord('author')
+      .randomize()
+      .save();
   }
 
   _generateSomeBooks(author) {
@@ -114,14 +110,14 @@ export default class SeederController extends Controller {
       const library = this._selectRandomLibrary();
 
       // Creating and saving book, saving the related records also are take while, they are all a Promise.
-      const bookPromise =
-        this.store.createRecord('book')
-          .randomize(author, library)
-          .save()
-          .then(() => author.save())
+      const bookPromise = this.store
+        .createRecord('book')
+        .randomize(author, library)
+        .save()
+        .then(() => author.save())
 
-          // guard library in case if we don't have any
-          .then(() => library && library.save());
+        // guard library in case if we don't have any
+        .then(() => library && library.save());
       books.push(bookPromise);
     }
 
@@ -130,7 +126,6 @@ export default class SeederController extends Controller {
   }
 
   _selectRandomLibrary() {
-
     // Please note libraries are records from store, which means this is a DS.RecordArray object, it is extended from
     // Ember.ArrayProxy. If you need an element from this list, you cannot just use libraries[3], we have to use
     // libraries.objectAt(3)
@@ -143,7 +138,6 @@ export default class SeederController extends Controller {
   }
 
   _destroyAll(records) {
-
     // destroyRecord() is a Promise and will be fulfilled when the backend database is confirmed the delete
     // lets collect these Promises in an array
     const recordsAreDestroying = records.map(item => item.destroyRecord());

--- a/app/controllers/authors.js
+++ b/app/controllers/authors.js
@@ -2,7 +2,6 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 
 export default class AuthorsController extends Controller {
-
   @action
   editAuthor(author) {
     author.set('isEditing', true);

--- a/app/controllers/books.js
+++ b/app/controllers/books.js
@@ -42,8 +42,8 @@ export default class BooksController extends Controller {
   @action
   saveAuthor(author, book) {
     // Firebase adapter is buggy, we have to manually remove the previous relation
-    book.author.then((previousAuthor) => {
-      previousAuthor.books.then((previousAuthorBooks) => {
+    book.author.then(previousAuthor => {
+      previousAuthor.books.then(previousAuthorBooks => {
         previousAuthorBooks.removeObject(book);
         previousAuthor.save();
       });
@@ -71,8 +71,8 @@ export default class BooksController extends Controller {
     // Firebase adapter is buggy, we have to manually remove the previous relation.
     // You don't need this callback mess when your adapter properly manages relations.
     // If Firebase fix this bug, we can remove this part.
-    book.library.then((previousLibrary) => {
-      previousLibrary.books.then((previousLibraryBooks) => {
+    book.library.then(previousLibrary => {
+      previousLibrary.books.then(previousLibraryBooks => {
         previousLibraryBooks.removeObject(book);
         previousLibrary.save();
       });

--- a/app/controllers/contact.js
+++ b/app/controllers/contact.js
@@ -2,7 +2,6 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 
 export default class ContactController extends Controller {
-
   @action
   sendMessage(newContactMessage) {
     newContactMessage.save().then(() => this.set('responseMessage', true));

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -4,7 +4,6 @@ import { match, not } from '@ember/object/computed';
 import { tracked } from '@glimmer/tracking';
 
 export default class HomeController extends Controller {
-
   headerMessage = 'Demo Home Page';
   @tracked responseMessage = '';
   @tracked emailAddress = '';
@@ -17,7 +16,7 @@ export default class HomeController extends Controller {
     const newInvitation = this.store.createRecord('invitation', { email: this.emailAddress });
 
     newInvitation.save().then(response => {
-      this.responseMessage = `Thank you! We saved your email address with the following id: ${ response.id }`;
+      this.responseMessage = `Thank you! We saved your email address with the following id: ${response.id}`;
       this.emailAddress = '';
     });
   }

--- a/app/controllers/libraries/index.js
+++ b/app/controllers/libraries/index.js
@@ -4,7 +4,6 @@ import { equal } from '@ember/object/computed';
 import { tracked } from '@glimmer/tracking';
 
 export default class LibrariesIndexController extends Controller {
-
   @tracked queryParams = ['filter', 'limit', 'letter'];
   @tracked filter = '';
   @tracked letter = '';
@@ -13,7 +12,6 @@ export default class LibrariesIndexController extends Controller {
   @equal('limit', 'all') limitAll;
 
   get filteredList() {
-
     let results = this.model;
     const query = this.filter;
 
@@ -24,7 +22,7 @@ export default class LibrariesIndexController extends Controller {
       // i: case insensitive, g: global
       const regex = new RegExp(regexString, 'ig');
 
-      results = results.filter((item) => item.name.match(regex));
+      results = results.filter(item => item.name.match(regex));
     }
 
     return results.sortBy('name');

--- a/app/helpers/is-equal.js
+++ b/app/helpers/is-equal.js
@@ -1,6 +1,6 @@
 import { helper } from '@ember/component/helper';
 
-export function isEqual(params/*, hash*/) {
+export function isEqual(params /*, hash*/) {
   return params[0] === params[1];
 }
 

--- a/app/index.html
+++ b/app/index.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>LibraryApp - Ember Octane Tutorial</title>
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     {{content-for "head"}}
 
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/library-app.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/library-app.css" />
 
     {{content-for "head-footer"}}
   </head>

--- a/app/models/author.js
+++ b/app/models/author.js
@@ -3,7 +3,6 @@ import { empty } from '@ember/object/computed';
 import Faker from 'faker';
 
 export default Model.extend({
-
   name: attr('string'),
   books: hasMany('book', { inverse: 'author', async: true }),
 
@@ -16,5 +15,5 @@ export default Model.extend({
     // for example `this.store.createRecord('author').randomize().save()`,
     // check in Seeder Controller.
     return this;
-  }
+  },
 });

--- a/app/models/book.js
+++ b/app/models/book.js
@@ -2,7 +2,6 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 import Faker from 'faker';
 
 export default Model.extend({
-
   title: attr('string'),
   releaseYear: attr('date'),
 
@@ -28,5 +27,5 @@ export default Model.extend({
 
   _getRandomArbitrary(min, max) {
     return Math.random() * (max - min) + min;
-  }
+  },
 });

--- a/app/models/contact.js
+++ b/app/models/contact.js
@@ -2,7 +2,6 @@ import Model, { attr } from '@ember-data/model';
 import { match, gte, and, not } from '@ember/object/computed';
 
 export default Model.extend({
-
   email: attr('string'),
   message: attr('string'),
 
@@ -10,5 +9,5 @@ export default Model.extend({
   isMessageLongEnough: gte('message.length', 5),
 
   isValid: and('isValidEmail', 'isMessageLongEnough'),
-  isNotValid: not('isValid')
+  isNotValid: not('isValid'),
 });

--- a/app/models/invitation.js
+++ b/app/models/invitation.js
@@ -1,7 +1,5 @@
 import Model, { attr } from '@ember-data/model';
 
 export default Model.extend({
-
-  email: attr('string')
-
+  email: attr('string'),
 });

--- a/app/models/library.js
+++ b/app/models/library.js
@@ -3,7 +3,6 @@ import { notEmpty } from '@ember/object/computed';
 import Faker from 'faker';
 
 export default Model.extend({
-
   name: attr('string'),
   address: attr('string'),
   phone: attr('string'),
@@ -23,5 +22,5 @@ export default Model.extend({
 
   _fullAddress() {
     return `${Faker.address.streetAddress()}, ${Faker.address.city()}`;
-  }
+  },
 });

--- a/app/routes/about.js
+++ b/app/routes/about.js
@@ -1,4 +1,3 @@
 import Route from '@ember/routing/route';
 
-export default Route.extend({
-});
+export default Route.extend({});

--- a/app/routes/admin/contacts.js
+++ b/app/routes/admin/contacts.js
@@ -1,8 +1,7 @@
 import Route from '@ember/routing/route';
 
 export default Route.extend({
-
   model() {
     return this.store.findAll('contact');
-  }
+  },
 });

--- a/app/routes/admin/invitations.js
+++ b/app/routes/admin/invitations.js
@@ -1,8 +1,7 @@
 import Route from '@ember/routing/route';
 
 export default Route.extend({
-
   model() {
     return this.store.findAll('invitation');
-  }
+  },
 });

--- a/app/routes/admin/seeder.js
+++ b/app/routes/admin/seeder.js
@@ -2,7 +2,6 @@ import { hash } from 'rsvp';
 import Route from '@ember/routing/route';
 
 export default Route.extend({
-
   // You can use these lines to experiment with route hooks.
   // Uncomment these and comment out the real implementation below.
   // Open inspection console in your browser and check how Ember call
@@ -40,7 +39,7 @@ export default Route.extend({
     return hash({
       libraries: this.store.findAll('library'),
       books: this.store.findAll('book'),
-      authors: this.store.findAll('author')
+      authors: this.store.findAll('author'),
     });
   },
 
@@ -50,5 +49,5 @@ export default Route.extend({
     controller.set('authors', model.authors);
 
     this._super(controller, model);
-  }
+  },
 });

--- a/app/routes/authors.js
+++ b/app/routes/authors.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
 
 export default class AuthorsRoute extends Route {
-
   model() {
     return this.store.findAll('author');
   }

--- a/app/routes/books.js
+++ b/app/routes/books.js
@@ -6,7 +6,7 @@ export default class BooksRoute extends Route {
     return hash({
       books: this.store.findAll('book'),
       authors: this.store.findAll('author'),
-      libraries: this.store.findAll('library')
+      libraries: this.store.findAll('library'),
     });
   }
 }

--- a/app/routes/contact.js
+++ b/app/routes/contact.js
@@ -2,7 +2,6 @@ import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 
 export default class ContactRoute extends Route {
-
   model() {
     return this.store.createRecord('contact');
   }

--- a/app/routes/libraries/edit.js
+++ b/app/routes/libraries/edit.js
@@ -2,7 +2,6 @@ import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 
 export default class LibrariesEditRoute extends Route {
-
   model(params) {
     return this.store.findRecord('library', params.library_id);
   }

--- a/app/routes/libraries/index.js
+++ b/app/routes/libraries/index.js
@@ -1,14 +1,12 @@
 import Route from '@ember/routing/route';
 
 export default class LibrariesIndexRoute extends Route {
-
   queryParams = {
     limit: { refreshModel: true },
-    letter: { refreshModel: true }
-  }
+    letter: { refreshModel: true },
+  };
 
   model(params) {
-
     if (params.limit === 'all') {
       return this.store.findAll('library');
     }
@@ -16,7 +14,7 @@ export default class LibrariesIndexRoute extends Route {
     return this.store.query('library', {
       orderBy: 'name',
       startAt: params.letter,
-      endAt: params.letter+"\uf8ff"
+      endAt: params.letter + '\uf8ff',
     });
   }
 }

--- a/app/routes/libraries/new.js
+++ b/app/routes/libraries/new.js
@@ -2,7 +2,6 @@ import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 
 export default class LibrariesNewRoute extends Route {
-
   model() {
     return this.store.createRecord('library');
   }

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,10 +1,9 @@
 import RealtimeDatabaseSerializer from 'emberfire/serializers/realtime-database';
 
 export default class ApplicationSerializer extends RealtimeDatabaseSerializer {
-
   // Fixing a Firebase bug. https://github.com/firebase/emberfire/pull/600
   // eslint-disable-next-line no-unused-vars
   normalizeCreateRecordResponse(_store, _primaryModelClass, payload, id, _requestType) {
-    return {data: {id: id || payload.ref.key, attributes: payload.data, type: _primaryModelClass.modelName}};
+    return { data: { id: id || payload.ref.key, attributes: payload.data, type: _primaryModelClass.modelName } };
   }
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -36,11 +36,11 @@ html {
 }
 
 .vtop {
-  vertical-align: top!important;
+  vertical-align: top !important;
 }
 
 .not-bold {
-  font-weight: normal!important;
+  font-weight: normal !important;
 }
 
 th.wider {

--- a/app/styles/spinner.scss
+++ b/app/styles/spinner.scss
@@ -15,50 +15,65 @@
 }
 .sk-cube-grid .sk-cube1 {
   -webkit-animation-delay: 0.2s;
-  animation-delay: 0.2s; }
+  animation-delay: 0.2s;
+}
 .sk-cube-grid .sk-cube2 {
   -webkit-animation-delay: 0.3s;
-  animation-delay: 0.3s; }
+  animation-delay: 0.3s;
+}
 .sk-cube-grid .sk-cube3 {
   -webkit-animation-delay: 0.4s;
-  animation-delay: 0.4s; }
+  animation-delay: 0.4s;
+}
 .sk-cube-grid .sk-cube4 {
   -webkit-animation-delay: 0.1s;
-  animation-delay: 0.1s; }
+  animation-delay: 0.1s;
+}
 .sk-cube-grid .sk-cube5 {
   -webkit-animation-delay: 0.2s;
-  animation-delay: 0.2s; }
+  animation-delay: 0.2s;
+}
 .sk-cube-grid .sk-cube6 {
   -webkit-animation-delay: 0.3s;
-  animation-delay: 0.3s; }
+  animation-delay: 0.3s;
+}
 .sk-cube-grid .sk-cube7 {
   -webkit-animation-delay: 0s;
-  animation-delay: 0s; }
+  animation-delay: 0s;
+}
 .sk-cube-grid .sk-cube8 {
   -webkit-animation-delay: 0.1s;
-  animation-delay: 0.1s; }
+  animation-delay: 0.1s;
+}
 .sk-cube-grid .sk-cube9 {
   -webkit-animation-delay: 0.2s;
-  animation-delay: 0.2s; }
+  animation-delay: 0.2s;
+}
 
 @-webkit-keyframes sk-cubeGridScaleDelay {
-  0%, 70%, 100% {
+  0%,
+  70%,
+  100% {
     -webkit-transform: scale3D(1, 1, 1);
     transform: scale3D(1, 1, 1);
-  } 35% {
-      -webkit-transform: scale3D(0, 0, 1);
-      transform: scale3D(0, 0, 1);
-    }
+  }
+  35% {
+    -webkit-transform: scale3D(0, 0, 1);
+    transform: scale3D(0, 0, 1);
+  }
 }
 
 @keyframes sk-cubeGridScaleDelay {
-  0%, 70%, 100% {
+  0%,
+  70%,
+  100% {
     -webkit-transform: scale3D(1, 1, 1);
     transform: scale3D(1, 1, 1);
-  } 35% {
-      -webkit-transform: scale3D(0, 0, 1);
-      transform: scale3D(0, 0, 1);
-    }
+  }
+  35% {
+    -webkit-transform: scale3D(0, 0, 1);
+    transform: scale3D(0, 0, 1);
+  }
 }
 
 // Spinner in a button.
@@ -69,11 +84,19 @@
 }
 
 @keyframes spin {
-  from { transform: scale(1) rotate(0deg); }
-  to { transform: scale(1) rotate(360deg); }
+  from {
+    transform: scale(1) rotate(0deg);
+  }
+  to {
+    transform: scale(1) rotate(360deg);
+  }
 }
 
 @-webkit-keyframes spin2 {
-  from { -webkit-transform: rotate(0deg); }
-  to { -webkit-transform: rotate(360deg); }
+  from {
+    -webkit-transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(360deg);
+  }
 }

--- a/config/coverage.js
+++ b/config/coverage.js
@@ -1,9 +1,6 @@
 const { modulePrefix } = require('./environment')();
 
 module.exports = {
-  excludes: [
-    '*/mirage/**/*',
-    `${modulePrefix}/*.js`
-  ],
-  reporters: ['lcov', 'text']
+  excludes: ['*/mirage/**/*', `${modulePrefix}/*.js`],
+  reporters: ['lcov', 'text'],
 };

--- a/config/dotenv.js
+++ b/config/dotenv.js
@@ -12,6 +12,6 @@ module.exports = function(/* env */) {
     ],
     fastbootAllowedKeys: [],
     failOnMissingKey: false,
-    path: path.join(path.dirname(__dirname), '.env')
-  }
+    path: path.join(path.dirname(__dirname), '.env'),
+  };
 };

--- a/config/dotenv.js
+++ b/config/dotenv.js
@@ -4,12 +4,7 @@ const path = require('path');
 
 module.exports = function(/* env */) {
   return {
-    clientAllowedKeys: [
-      'API_KEY',
-      'AUTH_DOMAIN',
-      'DATABASE_URL',
-      'PROJECT_ID'
-    ],
+    clientAllowedKeys: ['API_KEY', 'AUTH_DOMAIN', 'DATABASE_URL', 'PROJECT_ID'],
     fastbootAllowedKeys: [],
     failOnMissingKey: false,
     path: path.join(path.dirname(__dirname), '.env'),

--- a/config/environment.js
+++ b/config/environment.js
@@ -21,7 +21,7 @@ module.exports = function(environment) {
     contentSecurityPolicy: {
       'script-src': "'self' 'unsafe-eval' apis.google.com",
       'frame-src': "'self' https://*.firebaseapp.com",
-      'connect-src': "'self' wss://*.firebaseio.com https://*.googleapis.com"
+      'connect-src': "'self' wss://*.firebaseio.com https://*.googleapis.com",
     },
 
     EmberENV: {
@@ -31,14 +31,14 @@ module.exports = function(environment) {
       },
       EXTEND_PROTOTYPES: {
         // Prevent Ember Data from overriding Date.parse.
-        Date: false
-      }
+        Date: false,
+      },
     },
 
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
-    }
+    },
   };
 
   if (environment === 'development') {
@@ -62,10 +62,9 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-
     // We need this for activating Faker in production environment.
     ENV['ember-faker'] = {
-      enabled: true
+      enabled: true,
     };
   }
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -14,7 +14,7 @@ module.exports = function(environment) {
       apiKey: process.env.API_KEY,
       authDomain: process.env.AUTH_DOMAIN,
       databaseURL: process.env.DATABASE_URL,
-      projectId: process.env.PROJECT_ID
+      projectId: process.env.PROJECT_ID,
     },
 
     // if using ember-cli-content-security-policy

--- a/config/targets.js
+++ b/config/targets.js
@@ -1,10 +1,6 @@
 'use strict';
 
-const browsers = [
-  'last 1 Chrome versions',
-  'last 1 Firefox versions',
-  'last 1 Safari versions'
-];
+const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
 
 const isCI = !!process.env.CI;
 const isProduction = process.env.EMBER_ENV === 'production';
@@ -14,5 +10,5 @@ if (isCI || isProduction) {
 }
 
 module.exports = {
-  browsers
+  browsers,
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,8 +5,8 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
     babel: {
-      sourceMaps: 'inline'
-    }
+      sourceMaps: 'inline',
+    },
 
     // Add options here
   });

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "run-p lint:js:check format:check test"
+      "pre-push": "run-p lint:js:check format:check test"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,11 +13,15 @@
     "build": "ember build --environment=production",
     "codacy-coverage": "cat ./coverage/lcov.info | codacy-coverage",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
-    "lint:hbs": "ember-template-lint .",
-    "lint:js": "eslint .",
+    "lint:hbs": "ember-template-lint . --fix",
+    "lint:js": "eslint . --fix",
+    "lint:js:check": "eslint .",
     "start": "ember serve",
     "test": "ember test",
-    "test:coverage": "COVERAGE=true npm test"
+    "test:coverage": "COVERAGE=true run-s -l test",
+    "format": "prettier --list-different --write **/*.{js,ts,html,json,css,scss,md}",
+    "format:check": "prettier --check **/*.{js,ts,html,json,css,scss,md}",
+    "ci": "run-s -l lint:js:check format:check test"
   },
   "devDependencies": {
     "@ember/jquery": "^1.1.0",
@@ -57,10 +61,14 @@
     "ember-source": "~3.17.0",
     "ember-welcome-page": "^4.0.0",
     "emberfire": "^3.0.0-rc.6",
+    "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-ember": "^7.10.1",
     "eslint-plugin-node": "^11.0.0",
+    "eslint-plugin-prettier": "^3.1.2",
     "firebase": "^7.10.0",
     "loader.js": "^4.7.0",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^1.19.1",
     "qunit-dom": "^1.1.0",
     "sass": "^1.26.2"
   },

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-prettier": "^3.1.2",
     "firebase": "^7.10.0",
+    "husky": "^4.2.3",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1",
@@ -77,5 +78,10 @@
   },
   "ember": {
     "edition": "octane"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "run-p lint:js:check format:check test"
+    }
   }
 }

--- a/testem.js
+++ b/testem.js
@@ -1,12 +1,8 @@
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
-  launch_in_ci: [
-    'Chrome'
-  ],
-  launch_in_dev: [
-    'Chrome'
-  ],
+  launch_in_ci: ['Chrome'],
+  launch_in_dev: ['Chrome'],
   browser_start_timeout: 120,
   browser_args: {
     Chrome: {
@@ -17,8 +13,8 @@ module.exports = {
         '--disable-dev-shm-usage',
         '--mute-audio',
         '--remote-debugging-port=0',
-        '--window-size=1440,900'
-      ].filter(Boolean)
-    }
-  }
+        '--window-size=1440,900',
+      ].filter(Boolean),
+    },
+  },
 };

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
   env: {
-    embertest: true
-  }
+    embertest: true,
+  },
 };

--- a/tests/fixtures/alphabet.js
+++ b/tests/fixtures/alphabet.js
@@ -24,5 +24,5 @@ export default [
   'W',
   'X',
   'Y',
-  'Z'
+  'Z',
 ];

--- a/tests/fixtures/authors.js
+++ b/tests/fixtures/authors.js
@@ -1,5 +1,5 @@
 export default [
   { id: '1', name: 'Tanya Gutmann' },
   { id: '2', name: 'Ruthe Fisher' },
-  { id: '3', name: 'Rodrick Connelly' }
+  { id: '3', name: 'Rodrick Connelly' },
 ];

--- a/tests/fixtures/book.js
+++ b/tests/fixtures/book.js
@@ -1,4 +1,4 @@
 export default {
   author: { id: '3', name: 'Rodrick Connelly' },
-  library: { id: '3', name: 'Jerde - Bogisich Library' }
+  library: { id: '3', name: 'Jerde - Bogisich Library' },
 };

--- a/tests/fixtures/libraries.js
+++ b/tests/fixtures/libraries.js
@@ -1,5 +1,5 @@
 export default [
   { id: '1', name: 'Nienow Group Library' },
   { id: '2', name: 'Gerlach and Sons Library' },
-  { id: '3', name: 'Jerde - Bogisich Library' }
+  { id: '3', name: 'Jerde - Bogisich Library' },
 ];

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -5,7 +5,7 @@ const resolver = Resolver.create();
 
 resolver.namespace = {
   modulePrefix: config.modulePrefix,
-  podModulePrefix: config.podModulePrefix
+  podModulePrefix: config.podModulePrefix,
 };
 
 export default resolver;

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,25 +1,22 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>LibraryApp Tests</title>
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    {{content-for "head"}}
-    {{content-for "test-head"}}
+    {{content-for "head"}} {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/library-app.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
+    <link rel="stylesheet" href="{{rootURL}}assets/library-app.css" />
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css" />
 
-    {{content-for "head-footer"}}
-    {{content-for "test-head-footer"}}
+    {{content-for "head-footer"}} {{content-for "test-head-footer"}}
   </head>
   <body>
-    {{content-for "body"}}
-    {{content-for "test-body"}}
+    {{content-for "body"}} {{content-for "test-body"}}
 
     <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
@@ -27,7 +24,6 @@
     <script src="{{rootURL}}assets/library-app.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
-    {{content-for "body-footer"}}
-    {{content-for "test-body-footer"}}
+    {{content-for "body-footer"}} {{content-for "test-body-footer"}}
   </body>
 </html>

--- a/tests/integration/components/abc-buttons-test.js
+++ b/tests/integration/components/abc-buttons-test.js
@@ -8,7 +8,6 @@ module('Integration | Component | abc-buttons', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-
     await render(hbs`{{abc-buttons}}`);
 
     const component = this.element.querySelector('div');

--- a/tests/integration/components/author-select-test.js
+++ b/tests/integration/components/author-select-test.js
@@ -9,26 +9,17 @@ module('Integration | Component | author-select', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-
     assert.expect(5);
 
     const saveAuthor = (authorRecord, bookRecord) => {
-      assert.deepEqual(
-        authorRecord,
-        authors[1],
-        'action called with proper author'
-      );
-      assert.deepEqual(
-        bookRecord,
-        book,
-        'action called with proper book'
-      );
-    }
+      assert.deepEqual(authorRecord, authors[1], 'action called with proper author');
+      assert.deepEqual(bookRecord, book, 'action called with proper book');
+    };
 
     this.setProperties({
       authors,
       book,
-      saveAuthor
+      saveAuthor,
     });
 
     await render(
@@ -39,19 +30,16 @@ module('Integration | Component | author-select', function(hooks) {
           @default={{book.author}}
           @onChange={{action saveAuthor}}
         />
-      `
+      `,
     );
 
     const component = this.element.querySelector('select');
 
-    assert.dom(component).hasClass(
-      'form-control',
-      'component renders with assigned CSS class'
-    );
+    assert.dom(component).hasClass('form-control', 'component renders with assigned CSS class');
     assert.equal(
       component.options[component.selectedIndex].text,
       'Tanya Gutmann',
-      'component renders with default author selected'
+      'component renders with default author selected',
     );
 
     await fillIn('.form-control', '2');
@@ -59,7 +47,7 @@ module('Integration | Component | author-select', function(hooks) {
     assert.equal(
       component.options[component.selectedIndex].text,
       'Ruthe Fisher',
-      'component renders changed selection'
+      'component renders changed selection',
     );
   });
 });

--- a/tests/integration/components/library-select-test.js
+++ b/tests/integration/components/library-select-test.js
@@ -9,15 +9,12 @@ module('Integration | Component | library-select', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-
     this.setProperties({
       libraries,
-      book
+      book,
     });
 
-    await render(
-      hbs`{{library-select libraries=libraries default=book.library}}`
-    );
+    await render(hbs`{{library-select libraries=libraries default=book.library}}`);
 
     const component = this.element.querySelector('select');
 
@@ -26,7 +23,7 @@ module('Integration | Component | library-select', function(hooks) {
     assert.equal(
       component.options[component.selectedIndex].text,
       'Jerde - Bogisich Library',
-      'component renders with default library selected'
+      'component renders with default library selected',
     );
 
     await fillIn('.form-control', '2');
@@ -34,7 +31,7 @@ module('Integration | Component | library-select', function(hooks) {
     assert.equal(
       component.options[component.selectedIndex].text,
       'Gerlach and Sons Library',
-      'component renders changed selection'
+      'component renders changed selection',
     );
   });
 });

--- a/tests/integration/components/seeder-block-test.js
+++ b/tests/integration/components/seeder-block-test.js
@@ -7,7 +7,6 @@ module('Integration | Component | seeder-block', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders valid input', async function(assert) {
-
     await render(hbs`
       {{seeder-block
         sectionTitle="Libraries"
@@ -18,10 +17,7 @@ module('Integration | Component | seeder-block', function(hooks) {
     const sectionTitle = component.querySelector('h3').textContent;
     const formGroup = component.querySelector('.form-group');
     const input = component.querySelector('.form-control');
-    const [
-      generateBtn,
-      deleteBtn
-    ] = component.querySelectorAll('button');
+    const [generateBtn, deleteBtn] = component.querySelectorAll('button');
 
     await fillIn(input, 1);
     click(generateBtn);
@@ -38,16 +34,12 @@ module('Integration | Component | seeder-block', function(hooks) {
   });
 
   test('it renders invalid input', async function(assert) {
-
     await render(hbs`{{seeder-block}}`);
 
     const component = this.element.querySelector('div');
     const formGroup = component.querySelector('.form-group');
     const input = component.querySelector('.form-control');
-    const [
-      generateBtn,
-      deleteBtn
-    ] = component.querySelectorAll('button');
+    const [generateBtn, deleteBtn] = component.querySelectorAll('button');
 
     await fillIn(input, 101);
     assert.dom(formGroup).hasClass('has-error');
@@ -56,7 +48,6 @@ module('Integration | Component | seeder-block', function(hooks) {
   });
 
   test('it renders generate and delete in progress buttons', async function(assert) {
-
     await render(hbs`
       {{seeder-block
         sectionTitle="Authors with Books"
@@ -67,10 +58,7 @@ module('Integration | Component | seeder-block', function(hooks) {
 
     const component = this.element.querySelector('div');
     const sectionTitle = component.querySelector('h3').textContent;
-    const [
-      generateBtn,
-      deleteBtn
-    ] = component.querySelectorAll('button');
+    const [generateBtn, deleteBtn] = component.querySelectorAll('button');
 
     assert.expect(3);
     assert.equal(sectionTitle, 'Authors with Books');
@@ -79,7 +67,6 @@ module('Integration | Component | seeder-block', function(hooks) {
   });
 
   test('it renders generated and deleted labels', async function(assert) {
-
     await render(hbs`
       {{seeder-block
         generateReady=true
@@ -88,10 +75,7 @@ module('Integration | Component | seeder-block', function(hooks) {
     `);
 
     const component = this.element.querySelector('div');
-    const [
-      createdLabel,
-      deletedLabel
-    ] = component.querySelectorAll('span');
+    const [createdLabel, deletedLabel] = component.querySelectorAll('span');
 
     assert.expect(2);
     assert.dom(createdLabel).hasText('Created!');

--- a/tests/unit/components/fader-label-test.js
+++ b/tests/unit/components/fader-label-test.js
@@ -14,34 +14,22 @@ module('Unit | Component | fader-label', function(hooks) {
 
   test('tagName property', function(assert) {
     assert.expect(1);
-    assert.equal(
-      this.component.get('tagName'),
-      'span'
-    );
+    assert.equal(this.component.get('tagName'), 'span');
   });
 
   test('classNames property', function(assert) {
     assert.expect(1);
-    assert.deepEqual(
-      this.component.get('classNames'),
-      ['label label-success label-fade']
-    );
+    assert.deepEqual(this.component.get('classNames'), ['label label-success label-fade']);
   });
 
   test('classNameBindings property', function(assert) {
     assert.expect(1);
-    assert.deepEqual(
-      this.component.get('classNameBindings'),
-      ['isShowing:label-show']
-    );
+    assert.deepEqual(this.component.get('classNameBindings'), ['isShowing:label-show']);
   });
 
   test('isShowing property', function(assert) {
     assert.expect(1);
-    assert.equal(
-      this.component.get('isShowing'),
-      false
-    );
+    assert.equal(this.component.get('isShowing'), false);
   });
 
   test('isShowingChanged observer', function(assert) {

--- a/tests/unit/components/library-select-test.js
+++ b/tests/unit/components/library-select-test.js
@@ -21,18 +21,14 @@ module('Unit | Component | library-select', function(hooks) {
   test('change handler function', function(assert) {
     const { component } = this;
     const event = {
-      target: { value: '2' }
+      target: { value: '2' },
     };
     component.setProperties({
       libraries,
       book,
-      onChange: spy()
+      onChange: spy(),
     });
-    const {
-      libraries: libraryRecord,
-      book: bookRecord,
-      onChange
-    } = component;
+    const { libraries: libraryRecord, book: bookRecord, onChange } = component;
     component.change(event);
     assert.expect(1);
     assert.ok(onChange.calledOnceWith(libraryRecord[1], bookRecord));

--- a/tests/unit/components/nav-link-to-test.js
+++ b/tests/unit/components/nav-link-to-test.js
@@ -14,14 +14,11 @@ module('Unit | Component | nav-link-to', function(hooks) {
       loading: true,
       loadingHref: '#',
       _routing: {
-        generateURL: spy()
+        generateURL: spy(),
       },
-      _query: 'query'
+      _query: 'query',
     };
-    this.component = this
-      .owner
-      .factoryFor('component:nav-link-to')
-      .create(component);
+    this.component = this.owner.factoryFor('component:nav-link-to').create(component);
   });
 
   test('tagName property', function(assert) {
@@ -38,13 +35,9 @@ module('Unit | Component | nav-link-to', function(hooks) {
 
     component.setProperties({
       loading: false,
-      route: 'libraries'
+      route: 'libraries',
     });
     component.hrefForA;
-    assert.ok(component._routing.generateURL.calledOnceWith(
-      'libraries',
-      [],
-      'query'
-    ));
+    assert.ok(component._routing.generateURL.calledOnceWith('libraries', [], 'query'));
   });
 });

--- a/tests/unit/controllers/admin/seeder-test.js
+++ b/tests/unit/controllers/admin/seeder-test.js
@@ -16,7 +16,7 @@ module('Unit | Controller | admin/seeder', function(hooks) {
       _generateSomeBooks: stub().resolves('books'),
       authors: 'authors',
       books: 'books',
-      libraries: 'libraries'
+      libraries: 'libraries',
     };
     this.controller = this.owner.factoryFor('controller:admin/seeder').create(controller);
   });
@@ -88,7 +88,7 @@ module('Unit | Controller | admin/seeder', function(hooks) {
       const randomize = stub().returns({ save });
       const createRecord = stub().returns({ randomize });
       const controller = {
-        store: { createRecord }
+        store: { createRecord },
       };
       this.controller = this.owner.factoryFor('controller:admin/seeder').create(controller);
     });
@@ -121,7 +121,7 @@ module('Unit | Controller | admin/seeder', function(hooks) {
       const createRecord = stub().returns({ randomize });
       controller.setProperties({
         _selectRandomLibrary: stub().returns(library),
-        store: { createRecord }
+        store: { createRecord },
       });
       controller._generateSomeBooks(author);
       assert.expect(5);
@@ -138,9 +138,7 @@ module('Unit | Controller | admin/seeder', function(hooks) {
 
     test('_selectRandomLibrary function', function(assert) {
       const { controller } = this;
-      controller.set('libraries', EmberObject.create(
-        { length: 2, objectAt: spy() }
-      ));
+      controller.set('libraries', EmberObject.create({ length: 2, objectAt: spy() }));
       controller._selectRandomLibrary();
       assert.expect(1);
       assert.ok(controller.libraries.objectAt.calledOnce);

--- a/tests/unit/controllers/authors-test.js
+++ b/tests/unit/controllers/authors-test.js
@@ -22,7 +22,7 @@ module('Unit | Controller | authors', function(hooks) {
   test('cancelAuthorEdit action', function(assert) {
     const rollbackAttributes = spy();
     const author = EmberObject.create({
-      rollbackAttributes
+      rollbackAttributes,
     });
     controller.cancelAuthorEdit(author);
     assert.notOk(author.isEditing);
@@ -34,7 +34,7 @@ module('Unit | Controller | authors', function(hooks) {
     const author = EmberObject.create({
       isEditing: true,
       isNotValid: true,
-      save
+      save,
     });
     controller.saveAuthor(author);
     assert.expect(4);

--- a/tests/unit/controllers/books-test.js
+++ b/tests/unit/controllers/books-test.js
@@ -12,7 +12,7 @@ module('Unit | Controller | books', function(hooks) {
     const save = spy();
     this.book = EmberObject.create({
       rollbackAttributes,
-      save
+      save,
     });
     this.controller = this.owner.lookup('controller:books');
   });
@@ -22,7 +22,7 @@ module('Unit | Controller | books', function(hooks) {
     controller.set('model', {
       authors: 'authors',
       books: 'books',
-      libraries: 'libraries'
+      libraries: 'libraries',
     });
     assert.expect(3);
     assert.equal(controller.get('authors'), 'authors');
@@ -55,7 +55,7 @@ module('Unit | Controller | books', function(hooks) {
 
     book.setProperties({
       isEditing: true,
-      isNotValid: true
+      isNotValid: true,
     });
     controller.send('saveBook', book);
     assert.ok(book.get('isEditing'));

--- a/tests/unit/controllers/libraries/index-test.js
+++ b/tests/unit/controllers/libraries/index-test.js
@@ -29,18 +29,10 @@ module('Unit | Controller | libraries/index', function(hooks) {
     ];
 
     assert.expect(2);
-    assert.deepEqual(
-      controller.get('filteredList'),
-      controller.model,
-      'no filter'
-    );
+    assert.deepEqual(controller.get('filteredList'), controller.model, 'no filter');
 
     controller.set('filter', 'berg');
-    assert.deepEqual(
-      controller.get('filteredList'),
-      [controller.model.objectAt(0)],
-      'filter by `berg`'
-    );
+    assert.deepEqual(controller.get('filteredList'), [controller.model.objectAt(0)], 'filter by `berg`');
   });
 
   test('deleteLibrary action', function(assert) {

--- a/tests/unit/models/author-test.js
+++ b/tests/unit/models/author-test.js
@@ -7,13 +7,8 @@ module('Unit | Model | author', function(hooks) {
   setupTest(hooks);
 
   test('it exists', function(assert) {
-    const model = run(
-      () => this.owner.lookup('service:store').createRecord('author')
-    );
+    const model = run(() => this.owner.lookup('service:store').createRecord('author'));
     assert.expect(1);
-    assert.equal(
-      model.randomize().constructor.modelName,
-      'author'
-    );
+    assert.equal(model.randomize().constructor.modelName, 'author');
   });
 });

--- a/tests/unit/models/book-test.js
+++ b/tests/unit/models/book-test.js
@@ -7,13 +7,8 @@ module('Unit | Model | book', function(hooks) {
   setupTest(hooks);
 
   test('it exists', function(assert) {
-    const model = run(
-      () => this.owner.lookup('service:store').createRecord('book')
-    );
+    const model = run(() => this.owner.lookup('service:store').createRecord('book'));
     assert.expect(1);
-    assert.equal(
-      model.randomize().constructor.modelName,
-      'book'
-    );
+    assert.equal(model.randomize().constructor.modelName, 'book');
   });
 });

--- a/tests/unit/models/library-test.js
+++ b/tests/unit/models/library-test.js
@@ -7,13 +7,8 @@ module('Unit | Model | library', function(hooks) {
   setupTest(hooks);
 
   test('it exists', function(assert) {
-    const model = run(
-      () => this.owner.lookup('service:store').createRecord('library')
-    );
+    const model = run(() => this.owner.lookup('service:store').createRecord('library'));
     assert.expect(1);
-    assert.equal(
-      model.randomize().constructor.modelName,
-      'library'
-    );
+    assert.equal(model.randomize().constructor.modelName, 'library');
   });
 });

--- a/tests/unit/routes/admin/contacts-test.js
+++ b/tests/unit/routes/admin/contacts-test.js
@@ -10,8 +10,8 @@ module('Unit | Route | admin/contacts', hooks => {
   test('model hook', function(assert) {
     const route = this.owner.factoryFor('route:admin/contacts').create({
       store: {
-        findAll: stub().returns('contacts')
-      }
+        findAll: stub().returns('contacts'),
+      },
     });
     assert.expect(2);
     assert.equal(route.model(), 'contacts');

--- a/tests/unit/routes/admin/invitations-test.js
+++ b/tests/unit/routes/admin/invitations-test.js
@@ -10,8 +10,8 @@ module('Unit | Route | admin/invitations', function(hooks) {
   test('model hook', function(assert) {
     const route = this.owner.factoryFor('route:admin/invitations').create({
       store: {
-        findAll: stub().returns('invitations')
-      }
+        findAll: stub().returns('invitations'),
+      },
     });
     assert.expect(2);
     assert.equal(route.model(), 'invitations');

--- a/tests/unit/routes/admin/seeder-test.js
+++ b/tests/unit/routes/admin/seeder-test.js
@@ -12,16 +12,19 @@ module('Unit | Route | admin/seeder', function(hooks) {
     this.model = {
       authors: 'authors',
       books: 'books',
-      libraries: 'libraries'
+      libraries: 'libraries',
     };
     const findAll = stub()
-      .onFirstCall().returns('libraries')
-      .onSecondCall().returns('books')
-      .onThirdCall().returns('authors');
+      .onFirstCall()
+      .returns('libraries')
+      .onSecondCall()
+      .returns('books')
+      .onThirdCall()
+      .returns('authors');
     this.route = this.owner.factoryFor('route:admin/seeder').create({
       store: {
-        findAll
-      }
+        findAll,
+      },
     });
   });
 

--- a/tests/unit/routes/authors-test.js
+++ b/tests/unit/routes/authors-test.js
@@ -2,8 +2,7 @@ import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-const {stub} = sinon;
-
+const { stub } = sinon;
 
 module('Unit | Route | authors', hooks => {
   setupTest(hooks);
@@ -11,7 +10,7 @@ module('Unit | Route | authors', hooks => {
   test('model hook', function(assert) {
     this.findAll = stub().returns('authors');
     this.route = this.owner.factoryFor('route:authors').create({
-      store: {findAll: this.findAll}
+      store: { findAll: this.findAll },
     });
 
     assert.expect(2);

--- a/tests/unit/routes/books-test.js
+++ b/tests/unit/routes/books-test.js
@@ -11,16 +11,19 @@ module('Unit | Route | books', hooks => {
     const model = {
       books: 'books',
       authors: 'authors',
-      libraries: 'libraries'
+      libraries: 'libraries',
     };
     const findAll = stub()
-      .onFirstCall().returns('books')
-      .onSecondCall().returns('authors')
-      .onThirdCall().returns('libraries');
+      .onFirstCall()
+      .returns('books')
+      .onSecondCall()
+      .returns('authors')
+      .onThirdCall()
+      .returns('libraries');
     const route = this.owner.factoryFor('route:books').create({
       store: {
-        findAll
-      }
+        findAll,
+      },
     });
     assert.expect(4);
     assert.deepEqual(await route.model(), model);
@@ -28,5 +31,4 @@ module('Unit | Route | books', hooks => {
     assert.ok(findAll.calledWith('author'));
     assert.ok(findAll.calledWith('library'));
   });
-
 });

--- a/tests/unit/routes/contact-test.js
+++ b/tests/unit/routes/contact-test.js
@@ -15,10 +15,10 @@ module('Unit | Route | contact', hooks => {
       controller: EmberObject.create({
         model: EmberObject.create({
           isNew: true,
-          destroyRecord: this.destroyRecord
-        })
+          destroyRecord: this.destroyRecord,
+        }),
       }),
-      store: { createRecord: this.createRecord }
+      store: { createRecord: this.createRecord },
     });
   });
 

--- a/tests/unit/routes/libraries/edit-test.js
+++ b/tests/unit/routes/libraries/edit-test.js
@@ -12,22 +12,22 @@ module('Unit | Route | libraries/edit', hooks => {
     this.controller = EmberObject.create({
       model: EmberObject.create({
         hasDirtyAttributes: true,
-        rollbackAttributes: spy()
-      })
+        rollbackAttributes: spy(),
+      }),
     });
     this.route = this.owner.factoryFor('route:libraries/edit').create({
       controller: this.controller,
       render: spy(),
       store: {
-        findRecord: stub().returns('library')
+        findRecord: stub().returns('library'),
       },
-      transitionTo: spy()
+      transitionTo: spy(),
     });
   });
 
   test('model hook', function(assert) {
     const params = {
-      library_id: 42
+      library_id: 42,
     };
     assert.expect(2);
     assert.equal(this.route.model(params), 'library');
@@ -43,12 +43,12 @@ module('Unit | Route | libraries/edit', hooks => {
   test('willTransition action', function(assert) {
     const { controller, route } = this;
     const transition = {
-      abort: spy()
+      abort: spy(),
     };
     stub(window, 'confirm').returns(true);
     route.send('willTransition', transition);
     assert.expect(8);
-    assert.ok(confirm.calledOnceWith('Your changes haven\'t saved yet. Would you like to leave this form?'));
+    assert.ok(confirm.calledOnceWith("Your changes haven't saved yet. Would you like to leave this form?"));
     assert.ok(controller.get('model').rollbackAttributes.calledOnce);
     assert.ok(transition.abort.notCalled);
     controller.get('model').rollbackAttributes.resetHistory();
@@ -67,6 +67,5 @@ module('Unit | Route | libraries/edit', hooks => {
     assert.ok(transition.abort.notCalled);
     assert.ok(controller.get('model').rollbackAttributes.notCalled);
     confirm.restore();
-
   });
 });

--- a/tests/unit/routes/libraries/index-test.js
+++ b/tests/unit/routes/libraries/index-test.js
@@ -13,8 +13,8 @@ module('Unit | Route | libraries/index', hooks => {
     this.route = this.owner.factoryFor('route:libraries/index').create({
       store: {
         findAll: this.findAll,
-        query: this.query
-      }
+        query: this.query,
+      },
     });
   });
 
@@ -26,13 +26,13 @@ module('Unit | Route | libraries/index', hooks => {
 
   test('model hook', function(assert) {
     const params = {
-      limit: 'all'
+      limit: 'all',
     };
 
     const queryParams = {
       orderBy: 'name',
       startAt: params.letter,
-      endAt: params.letter+"\uf8ff"
+      endAt: params.letter + '\uf8ff',
     };
 
     assert.expect(4);

--- a/tests/unit/routes/libraries/new-test.js
+++ b/tests/unit/routes/libraries/new-test.js
@@ -11,16 +11,16 @@ module('Unit | Route | libraries/new', hooks => {
   hooks.beforeEach(function() {
     this.controller = EmberObject.create({
       model: {
-        rollbackAttributes: spy()
-      }
+        rollbackAttributes: spy(),
+      },
     });
     this.route = this.owner.factoryFor('route:libraries/new').create({
       controller: this.controller,
       render: spy(),
       store: {
-        createRecord: stub().returns('library')
+        createRecord: stub().returns('library'),
       },
-      transitionTo: spy()
+      transitionTo: spy(),
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -776,6 +776,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.8.7":
+  version "7.8.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
+  integrity sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.3.tgz#e02ad04fe262a657809327f578056ca15fd4d1b8"
@@ -1762,6 +1769,11 @@
   version "9.6.55"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.55.tgz#7cc1358c9c18e71f6c020e410962971863232cf5"
   integrity sha512-e/5tg8Ok0gSrN6pvHphnwTK0/CD9VPZrtZqpvvpEFAtfs+ZntusgGaWkf2lSEq1OFe2EDPeUMiMVpy4nZpJ4AQ==
+
+"@types/parse-json@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
+  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/rimraf@^2.0.2":
   version "2.0.3"
@@ -4744,6 +4756,11 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
+compare-versions@^3.5.1:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
+  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
+
 component-bind@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
@@ -4969,6 +4986,17 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+cosmiconfig@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
+  integrity sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.7.2"
 
 coveralls@^3.0.9:
   version "3.0.9"
@@ -7011,13 +7039,20 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-find-up@^4.1.0:
+find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+find-versions@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-3.2.0.tgz#10297f98030a786829681690545ef659ed1d254e"
+  integrity sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==
+  dependencies:
+    semver-regex "^2.0.0"
 
 find-yarn-workspace-root@^1.1.0, find-yarn-workspace-root@^1.2.1:
   version "1.2.1"
@@ -8137,6 +8172,22 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+husky@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-4.2.3.tgz#3b18d2ee5febe99e27f2983500202daffbc3151e"
+  integrity sha512-VxTsSTRwYveKXN4SaH1/FefRJYCtx+wx04sSVcOpD7N2zjoHxa+cEJ07Qg5NmV3HAK+IRKOyNVpi2YBIVccIfQ==
+  dependencies:
+    chalk "^3.0.0"
+    ci-info "^2.0.0"
+    compare-versions "^3.5.1"
+    cosmiconfig "^6.0.0"
+    find-versions "^3.2.0"
+    opencollective-postinstall "^2.0.2"
+    pkg-dir "^4.2.0"
+    please-upgrade-node "^3.2.0"
+    slash "^3.0.0"
+    which-pm-runs "^1.0.0"
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -8176,7 +8227,7 @@ ignore@^5.1.1, ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
-import-fresh@^3.0.0:
+import-fresh@^3.0.0, import-fresh@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
@@ -9101,6 +9152,11 @@ libnpx@10.2.2:
     which "^1.3.0"
     y18n "^4.0.0"
     yargs "^11.0.0"
+
+lines-and-columns@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
+  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
 linkify-it@^2.0.0:
   version "2.2.0"
@@ -10720,6 +10776,11 @@ open@^7.0.0:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
+opencollective-postinstall@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
+  integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
+
 opener@~1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
@@ -11032,6 +11093,16 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parse-json@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.0.0.tgz#73e5114c986d143efa3712d4ea24db9a4266f60f"
+  integrity sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+    lines-and-columns "^1.1.6"
+
 parse-ms@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-1.0.1.tgz#56346d4749d78f23430ca0c713850aef91aa361d"
@@ -11217,6 +11288,13 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
+pkg-dir@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
+
 pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
@@ -11230,6 +11308,13 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+please-upgrade-node@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
+  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
+  dependencies:
+    semver-compare "^1.0.0"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -11800,6 +11885,11 @@ regenerator-runtime@^0.13.2:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
+regenerator-runtime@^0.13.4:
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz#e96bf612a3362d12bb69f7e8f74ffeab25c7ac91"
+  integrity sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==
+
 regenerator-runtime@^0.9.5:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
@@ -12343,6 +12433,11 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
+
 semver-diff@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
@@ -12356,6 +12451,11 @@ semver-diff@^3.1.1:
   integrity sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==
   dependencies:
     semver "^6.3.0"
+
+semver-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
+  integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
 "semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
@@ -14136,6 +14236,11 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
+which-pm-runs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
+  integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
+
 which@1, which@^1.1.1, which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -14395,6 +14500,13 @@ yam@^1.0.0:
   dependencies:
     fs-extra "^4.0.2"
     lodash.merge "^4.6.0"
+
+yaml@^1.7.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.8.2.tgz#a29c03f578faafd57dcb27055f9a5d569cb0c3d9"
+  integrity sha512-omakb0d7FjMo3R1D2EbTKVIk6dAVLRxFXdLZMEUToeAvuqgG/YuHMuQOZ5fgk+vQ8cx+cnGKwyg+8g8PNT0xQg==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
 
 yargs-parser@^16.1.0:
   version "16.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6324,6 +6324,13 @@ err-code@^1.0.0:
   dependencies:
     prr "~1.0.1"
 
+error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
+  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
+  dependencies:
+    is-arrayish "^0.2.1"
+
 error@^7.0.0:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/error/-/error-7.2.1.tgz#eab21a4689b5f684fc83da84a0e390de82d94894"
@@ -6408,6 +6415,13 @@ escodegen@^1.11.0, escodegen@^1.8.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-prettier@^6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz#7b15e303bf9c956875c948f6b21500e48ded6a7f"
+  integrity sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==
+  dependencies:
+    get-stdin "^6.0.0"
+
 eslint-plugin-ember@^7.10.1:
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-7.10.1.tgz#9ec731f158fc76a293bfb8055eaceb6b978ae0e7"
@@ -6436,6 +6450,13 @@ eslint-plugin-node@^11.0.0:
     minimatch "^3.0.4"
     resolve "^1.10.1"
     semver "^6.1.0"
+
+eslint-plugin-prettier@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz#432e5a667666ab84ce72f945c72f77d996a5c9ba"
+  integrity sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
 
 eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"
@@ -6797,6 +6818,11 @@ fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.0.3, fast-glob@^3.1.1:
   version "3.2.2"
@@ -7422,6 +7448,11 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
@@ -8328,6 +8359,11 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+  integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
 is-binary-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
@@ -9078,6 +9114,16 @@ livereload-js@^2.3.0:
   resolved "https://registry.yarnpkg.com/livereload-js/-/livereload-js-2.4.0.tgz#447c31cf1ea9ab52fc20db615c5ddf678f78009c"
   integrity sha512-XPQH8Z2GDP/Hwz2PCDrh2mth4yFejwA1OZ/81Ti3LgKyhDcEjsSsqFWZojHG0va/duGd+WyosY7eXLDoOyqcPw==
 
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+    strip-bom "^3.0.0"
+
 loader-runner@^2.3.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -9635,6 +9681,11 @@ memory-streams@^0.1.3:
   integrity sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==
   dependencies:
     readable-stream "~1.0.2"
+
+memorystream@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
+  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -10221,7 +10272,7 @@ nopt@^4.0.1, nopt@~4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
-normalize-package-data@^2.0.0, normalize-package-data@^2.4.0, "normalize-package-data@~1.0.1 || ^2.0.0":
+normalize-package-data@^2.0.0, normalize-package-data@^2.3.2, normalize-package-data@^2.4.0, "normalize-package-data@~1.0.1 || ^2.0.0":
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -10385,6 +10436,21 @@ npm-registry-fetch@^5.0.1:
     minizlib "^2.0.0"
     npm-package-arg "^7.0.0"
     safe-buffer "^5.2.0"
+
+npm-run-all@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
+  integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    memorystream "^0.3.1"
+    minimatch "^3.0.4"
+    pidtree "^0.3.0"
+    read-pkg "^3.0.0"
+    shell-quote "^1.6.1"
+    string.prototype.padend "^3.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -10958,6 +11024,14 @@ parse-asn1@^5.0.0:
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
 
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
 parse-ms@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-1.0.1.tgz#56346d4749d78f23430ca0c713850aef91aa361d"
@@ -11071,6 +11145,13 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
+  dependencies:
+    pify "^3.0.0"
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -11101,6 +11182,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.0.7, picomatch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
   integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
+
+pidtree@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.0.tgz#f6fada10fccc9f99bf50e90d0b23d72c9ebc2e6b"
+  integrity sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==
 
 pify@^3.0.0:
   version "3.0.0"
@@ -11178,6 +11264,18 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-ms@^3.1.0:
   version "3.2.0"
@@ -11573,6 +11671,15 @@ read-package-tree@~5.1.6:
     once "^1.3.0"
     read-package-json "^2.0.0"
     readdir-scoped-modules "^1.0.0"
+
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
 
 read@1, read@~1.0.1, read@~1.0.7:
   version "1.0.7"
@@ -12379,6 +12486,11 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shell-quote@^1.6.1:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
+  integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
+
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
@@ -12915,6 +13027,14 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string.prototype.padend@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz#dc08f57a8010dc5c153550318f67e13adbb72ac3"
+  integrity sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
 
 string.prototype.startswith@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
- Add Prettier to format code
- Handlebar support is limited/experimental, not reliable, so there isn't proper hbs formatting at the moment
- Use `npm-run-all`, `run-s` and `run-p` to run tasks.
- Add Husky to run linter, formatter check and test before commit. (Maybe running test is overkill we can remove it.)

- Coverall and codacy integration is turned off in Travis, because something wrong with the parser.