### PR TITLE
enable Codacy coverage reporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Run tests & report coverage
+name: CI
 on: [push, pull_request]
 
 jobs:
@@ -28,12 +28,12 @@ jobs:
       - name: Lint and test
         run: yarn ci
 
-      - name: Coveralls
+      - name: Coveralls Coverage Reporter
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      #- name: Codacy
-        #uses: codacy/codacy-coverage-reporter-action@v1
-        #with:
-          #project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      - name: Codacy Coverage Reporter
+        uses: codacy/codacy-coverage-reporter-action@v1
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # Ember.js Octane Tutorial - Demo Application
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/3cc355a9c33d4f82b8c4ec6505b0636e)](https://app.codacy.com/app/zdebre/library-app?utm_source=github.com&utm_medium=referral&utm_content=zoltan-nz/library-app&utm_campaign=Badge_Grade_Settings)
-![CI](https://github.com/zoltan-nz/library-app/actions/workflows/ci.yml/badge.svg)
-[![coverage](https://coveralls.io/repos/github/zoltan-nz/library-app/badge.svg?branch=master)](https://coveralls.io/github/zoltan-nz/library-app?branch=master)
+[![CI Build Status][ci-badge]][ci-badge-url]
+[![Codacy Grade Status][codacy-badge]][codacy-badge-url]
+[![Coveralls Coverage Status][coveralls-badge]][coveralls-badge-url]
+
+[ci-badge]: https://github.com/zoltan-nz/library-app/workflows/CI/badge.svg
+[ci-badge-url]: https://github.com/zoltan-nz/library-app/actions?query=workflow:CI
+[codacy-badge]: https://api.codacy.com/project/badge/Grade/3cc355a9c33d4f82b8c4ec6505b0636e
+[codacy-badge-url]: https://app.codacy.com/app/zdebre/library-app
+[coveralls-badge]: https://coveralls.io/repos/github/zoltan-nz/library-app/badge.svg?branch=master
+[coveralls-badge-url]: https://coveralls.io/github/zoltan-nz/library-app?branch=master
 
 This is the original repository of the Library App.
 


### PR DESCRIPTION
@zoltan-nz looks like we still have issues with the `CODACY_PROJECT_TOKEN`. See [this run](https://github.com/zoltan-nz/library-app/runs/3210852863?check_suite_focus=true).

Did you set up a `CODACY_API_TOKEN` or `CODACY_PROJECT_TOKEN`? More [here](https://github.com/marketplace/actions/codacy-coverage-reporter#workflow-options).